### PR TITLE
Close & Dispose of the HttpWebResponse. Fixes #11

### DIFF
--- a/SharpRaven/RavenClient.cs
+++ b/SharpRaven/RavenClient.cs
@@ -128,7 +128,10 @@ namespace SharpRaven {
                     s.Close();
                 }
 
-                HttpWebResponse wr = (HttpWebResponse)request.GetResponse();
+                using (HttpWebResponse wr = (HttpWebResponse)request.GetResponse())
+                {
+                    wr.Close();
+                }
             } catch (WebException e) {
                 Console.ForegroundColor = ConsoleColor.Red;
                 Console.Write("[ERROR] ");


### PR DESCRIPTION
Pretty basic change, as per the issue, closes and disposes for the result HttpWebResponse.
