### PR TITLE
Client was logging stack trace in reverse

### DIFF
--- a/SharpRaven/Data/SentryStacktrace.cs
+++ b/SharpRaven/Data/SentryStacktrace.cs
@@ -10,11 +10,9 @@ namespace SharpRaven.Data {
     public class SentryStacktrace {
         public SentryStacktrace(Exception e) {
             StackTrace trace = new StackTrace(e);
-            this.Frames = new List<ExceptionFrame>();
 
-            for (int i = 0; i < trace.FrameCount; i++) {
-                StackFrame frame = trace.GetFrame(i);
-
+            this.Frames = trace.GetFrames().Reverse().Select(frame =>
+            {
                 int lineNo = frame.GetFileLineNumber();
 
                 if (lineNo == 0)
@@ -23,16 +21,16 @@ namespace SharpRaven.Data {
                     lineNo = frame.GetILOffset();
                 }
 
-                Frames.Add(new ExceptionFrame() {
+                return new ExceptionFrame()
+                {
                     Filename = frame.GetFileName(),
                     Module = frame.GetMethod().DeclaringType.FullName,
                     Function = frame.GetMethod().Name,
                     Source = frame.GetMethod().ToString(),
                     LineNumber = lineNo,
                     ColumnNumber = frame.GetFileColumnNumber()
-                });
-
-            }
+                };
+            }).ToList();
         }
 
         [JsonProperty(PropertyName = "frames")]


### PR DESCRIPTION
According to the Sentry docs, stack traces should be logged with the most recent frame [last](http://sentry.readthedocs.org/en/latest/developer/interfaces/index.html).

The .Net StackTrace class used by the library puts the most recent frame [first](http://msdn.microsoft.com/en-au/library/system.diagnostics.stacktrace.getframes.aspx) and hence the client was logging stack frames in reverse. 

I've reversed the stack trace, and dropped in a bit of linq because I think it reads a bit more nicely. 
