### PR TITLE
Fixed empty stacktrace info and a potential NullReferenceException when building an ExceptionFrame

### DIFF
--- a/SharpRaven/Data/SentryStacktrace.cs
+++ b/SharpRaven/Data/SentryStacktrace.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 
 using Newtonsoft.Json;
@@ -9,9 +10,9 @@ using Newtonsoft.Json;
 namespace SharpRaven.Data {
     public class SentryStacktrace {
         public SentryStacktrace(Exception e) {
-            StackTrace trace = new StackTrace(e);
+            StackTrace trace = new StackTrace(e, true);
 
-            this.Frames = trace.GetFrames().Reverse().Select(frame =>
+            Frames = trace.GetFrames().Reverse().Select(frame =>
             {
                 int lineNo = frame.GetFileLineNumber();
 
@@ -21,12 +22,13 @@ namespace SharpRaven.Data {
                     lineNo = frame.GetILOffset();
                 }
 
+                MethodBase method = frame.GetMethod();
                 return new ExceptionFrame()
                 {
                     Filename = frame.GetFileName(),
-                    Module = frame.GetMethod().DeclaringType.FullName,
-                    Function = frame.GetMethod().Name,
-                    Source = frame.GetMethod().ToString(),
+                    Module = method.DeclaringType == null ? "" : method.DeclaringType.FullName,
+                    Function = method.Name,
+                    Source = method.ToString(),
                     LineNumber = lineNo,
                     ColumnNumber = frame.GetFileColumnNumber()
                 };


### PR DESCRIPTION
Fixed empty stacktrace info and added a check to prevent an exception from being thrown when building an ExceptionFrame and a method in the stack has no declaring type (e.g. a lambda expression)
