### PR TITLE
Prevent NullReference in RavenClient

### DIFF
--- a/SharpRaven/RavenClient.cs
+++ b/SharpRaven/RavenClient.cs
@@ -139,10 +139,14 @@ namespace SharpRaven {
                 Console.WriteLine(e.Message);
 
                 string messageBody = String.Empty;
-                using (StreamReader sw = new StreamReader(e.Response.GetResponseStream())) {
-                    messageBody = sw.ReadToEnd();
+                if (e.Response != null)
+                {
+                    using (StreamReader sw = new StreamReader(e.Response.GetResponseStream()))
+                    {
+                        messageBody = sw.ReadToEnd();
+                    }
+                    Console.WriteLine("[MESSAGE BODY] " + messageBody);
                 }
-                Console.WriteLine("[MESSAGE BODY] " + messageBody);
                 
                 return false;
             }


### PR DESCRIPTION
Stop Raven for crashing if e.Response is null after a web exception has occurred during a send to sentry
