### PR TITLE
Fix for error handling in case of WebException

### DIFF
--- a/SharpRaven/RavenClient.cs
+++ b/SharpRaven/RavenClient.cs
@@ -60,9 +60,9 @@ namespace SharpRaven {
             packet.Tags = tags;
             packet.Extra = extra;
 
-            Send(packet, CurrentDSN);
+            bool success = Send(packet, CurrentDSN);
 
-            return 0;
+            return (success) ? 0 : 1;
         }
 
         public int CaptureMessage(string message)
@@ -88,9 +88,9 @@ namespace SharpRaven {
             packet.Tags = tags;
             packet.Extra = extra;
 
-            Send(packet, CurrentDSN);
+            bool success = Send(packet, CurrentDSN);
 
-            return 0;
+            return (success) ? 0 : 1;
         }
 
         public bool Send(JsonPacket packet, DSN dsn) {


### PR DESCRIPTION
Hi,

in case there is an error with the request, we store our log locally, but this was impossible to detect in the current implementation, as the return value from Send is discarded.
