### PR TITLE
remove usage of old ssl3 protocol

### DIFF
--- a/src/app/SharpRaven/RavenClient.cs
+++ b/src/app/SharpRaven/RavenClient.cs
@@ -169,7 +169,6 @@ namespace SharpRaven
                 request.Method = "POST";
                 request.Accept = "application/json";
                 request.Headers.Add("X-Sentry-Auth", PacketBuilder.CreateAuthenticationHeader(dsn));
-                ServicePointManager.SecurityProtocol = SecurityProtocolType.Ssl3;
                 request.UserAgent = PacketBuilder.UserAgent;
 
                 if (Compression)


### PR DESCRIPTION
today Sentry have shut off access via SSLv3 because of this exploit announced: http://googleonlinesecurity.blogspot.com/2014/10/this-poodle-bites-exploiting-ssl-30.html
