### PR TITLE
Don't crash when HttpContext exists without a request

### DIFF
--- a/src/app/SharpRaven/Data/SentryRequest.cs
+++ b/src/app/SharpRaven/Data/SentryRequest.cs
@@ -149,8 +149,17 @@ namespace SharpRaven.Data
         /// </returns>
         public static SentryRequest GetRequest()
         {
-            var request = new SentryRequest();
-            return HasHttpContext ? request : null;
+            try
+            {
+                var request = new SentryRequest();
+                return HasHttpContext ? request : null;
+            }
+            catch (Exception exception)
+            {
+                Console.WriteLine(exception);
+            }
+
+            return null;
         }
 
 


### PR DESCRIPTION
If we're logging an exception that originated in Application_Start of Global.asax, we will have an HttpContext without a request. Trying to access the Request property when there is no request will not just return null, it actually results in an HttpException with the message "Request is not available in this context". No exception is logged to Sentry.

With this fix, the exception is logged to Sentry, even if there is no request on HttpContext.