### PR TITLE
Added special handling for ReflectionTypeLoadException

### DIFF
--- a/src/app/SharpRaven/Data/JsonPacket.cs
+++ b/src/app/SharpRaven/Data/JsonPacket.cs
@@ -30,6 +30,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 
 using Newtonsoft.Json;
 
@@ -81,6 +82,18 @@ namespace SharpRaven.Data
                 };
 
                 Exceptions.Add(sentryException);
+            }
+
+            // ReflectionTypeLoadException doesn't contain much useful info in itself, and needs special handling
+            ReflectionTypeLoadException reflectionTypeLoadException = exception as ReflectionTypeLoadException;
+            if (reflectionTypeLoadException != null)
+            {
+                foreach (Exception loaderException in reflectionTypeLoadException.LoaderExceptions)
+                {
+                    SentryException sentryException = new SentryException(loaderException);
+
+                    Exceptions.Add(sentryException);
+                }
             }
         }
 


### PR DESCRIPTION
The ReflectionTypeLoadException is a weird one, it only gives us this message in Sentry: "Unable to load one or more of the requested types. Retrieve the LoaderExceptions property for more information."

This fix will include the LoaderExceptions, which contains the actual useful info, in the json document that is sent to Sentry.