### PR TITLE
Skyp dynamic assembly on GetModules()

### DIFF
--- a/src/app/SharpRaven/Utilities/SystemUtil.cs
+++ b/src/app/SharpRaven/Utilities/SystemUtil.cs
@@ -49,6 +49,7 @@ namespace SharpRaven.Utilities
         {
             var assemblies = AppDomain.CurrentDomain
                                       .GetAssemblies()
+                                      .Where(q => !q.IsDynamic)
                                       .Select(a => a.GetName())
                                       .OrderBy(a => a.Name);
 


### PR DESCRIPTION
Hello, i'm not really sure the problem on production environment is associated to the GetModules() method but it could be.

Sometimes when iis try to recycle the application pool and an error is fired to log on sentry i get a lot of errors with the following exception "System.Reflection.RuntimeAssembly in _nLoad, Collection was modified; enumeration operation may not execute" and the cause should be the App_Web_xxxxxx asp .NET dynamic assemblies not available anymore. The frequency of the problem is really low. The latest two cases are: 2015-02-17 and 2015-02-08. When this problem occur the web site is not even able to render the 500 error page and a white page is sent to the client. So is really critical.

I will hope you merge the pull request :)