### PR TITLE
Issue #111 - Addresses issue with JsonPacket not being fully built by JsonPacketFactory when passing SentryEvent

### DIFF
--- a/src/app/SharpRaven/Data/JsonPacketFactory.cs
+++ b/src/app/SharpRaven/Data/JsonPacketFactory.cs
@@ -132,8 +132,10 @@ namespace SharpRaven.Data
         /// </returns>
         public JsonPacket Create(string project, SentryEvent @event)
         {
-            var json = new JsonPacket(project, @event);
-            return OnCreate(json);
+
+            return @event.Exception == null ?
+                Create(project, @event.Message, @event.Level, @event.Tags, @event.Fingerprint.ToArray(), @event.Extra) :
+                Create(project, @event.Exception, @event.Message, @event.Level, @event.Tags, @event.Fingerprint.ToArray(), @event.Extra);
         }
 
 


### PR DESCRIPTION
Fixes issue #111 by calling by determining what type of SentryEvent is being passed as a parameter (Exception or Message) and calling other existing factory methods to fully build the JsonPacket model.