### PR TITLE
Log level is not set on JsonPacket

### DIFF
--- a/src/app/SharpRaven/Data/JsonPacket.cs
+++ b/src/app/SharpRaven/Data/JsonPacket.cs
@@ -74,6 +74,7 @@ namespace SharpRaven.Data
                 Initialize(@event.Exception);
 
             Message = @event.Message != null ? @event.Message.ToString() : null;
+            Level = @event.Level;
             Extra = Merge(@event);
             Tags = @event.Tags;
             Fingerprint = @event.Fingerprint.ToArray();


### PR DESCRIPTION
Hello, i was trying the new client with version 2.1.0-unstable0020 and every log message is logged as Error, it's seems you missed to set the ``Level`` property on new ``JsonPacket(string project, SentryEvent @event)`` constructor.