### PR TITLE
Skip empty dictionary on "Additional Data"

### DIFF
--- a/src/app/SharpRaven/Data/ExceptionData.cs
+++ b/src/app/SharpRaven/Data/ExceptionData.cs
@@ -70,6 +70,12 @@ namespace SharpRaven.Data
                 return;
 
             var exceptionData = new ExceptionData(exception.InnerException);
+
+            if (exceptionData.Count == 0)
+            {
+                return;
+            }
+
             exceptionData.AddTo(this);
         }
 


### PR DESCRIPTION
Hello again, to skip an empty entry on Sentry "Additional Data" tab i added a simple sanity check.

![empty-entry](https://cloud.githubusercontent.com/assets/2994719/14143246/95bf4afc-f68a-11e5-93af-9db02595578f.png)
