### PR TITLE
SentryRequest.Data is empty

### DIFF
--- a/src/app/SharpRaven/Data/SentryRequestFactory.cs
+++ b/src/app/SharpRaven/Data/SentryRequestFactory.cs
@@ -121,27 +121,29 @@ namespace SharpRaven.Data
         }
 
 
-        private static string BodyConvert()
+        private static object BodyConvert()
         {
             if (!HasHttpContext)
                 return null;
-
-            string body = String.Empty;
 
             try
             {
                 if (HttpContext.Request.Form.Count > 0)
                 {
-                    body = HttpContext.Request.Form;
+                    return Convert(x => x.Request.Form);
                 }
                 else
                 {
+                    string body = String.Empty;
+
                     using (MemoryStream stream = new MemoryStream())
                     {
                         HttpContext.Request.InputStream.Seek(0, SeekOrigin.Begin);
                         HttpContext.Request.InputStream.CopyTo(stream);
                         body = Encoding.UTF8.GetString(stream.ToArray());
                     }
+
+                    return body;
                 }
             }
             catch (Exception exception)
@@ -149,7 +151,7 @@ namespace SharpRaven.Data
                 Console.WriteLine(exception);
             }
 
-            return body;
+            return null;
         }
 
 

--- a/src/app/SharpRaven/SharpRaven.csproj
+++ b/src/app/SharpRaven/SharpRaven.csproj
@@ -14,7 +14,6 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>7a5c1353</NuGetPackageImportStamp>
-    <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug 4.0|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -124,7 +123,5 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\GitVersionTask.3.4.1\Build\portable-net+sl+win+wpa+wp\GitVersionTask.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\GitVersionTask.3.4.1\Build\portable-net+sl+win+wpa+wp\GitVersionTask.targets'))" />
-    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
   </Target>
-  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
 </Project>

--- a/src/app/SharpRaven/SharpRaven.csproj
+++ b/src/app/SharpRaven/SharpRaven.csproj
@@ -14,6 +14,7 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <TargetFrameworkProfile />
     <NuGetPackageImportStamp>7a5c1353</NuGetPackageImportStamp>
+    <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug 4.0|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
@@ -123,5 +124,7 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\..\packages\GitVersionTask.3.4.1\Build\portable-net+sl+win+wpa+wp\GitVersionTask.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\GitVersionTask.3.4.1\Build\portable-net+sl+win+wpa+wp\GitVersionTask.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
   </Target>
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
 </Project>


### PR DESCRIPTION
Hello, when the current HttpRequest is not an application/x-www-form-urlencoded the SentryRequest.Data will be empty, and the POST data will not be logged. I tried the attached patch on WebAPI and it seems working.