### PR TITLE
Improved logging

### DIFF
--- a/src/tests/SharpRaven.UnitTests/Integration/CaptureAsyncTests.cs
+++ b/src/tests/SharpRaven.UnitTests/Integration/CaptureAsyncTests.cs
@@ -59,7 +59,6 @@ namespace SharpRaven.UnitTests.Integration
             Helper.PrintInfo("Sentry Uri: " + this.ravenClient.CurrentDsn.SentryUri);
             Helper.PrintInfo("Port: " + this.ravenClient.CurrentDsn.Port);
             Helper.PrintInfo("Public Key: " + this.ravenClient.CurrentDsn.PublicKey);
-            Helper.PrintInfo("Private Key: " + this.ravenClient.CurrentDsn.PrivateKey);
             Helper.PrintInfo("Project ID: " + this.ravenClient.CurrentDsn.ProjectID);
         }
 
@@ -81,7 +80,6 @@ namespace SharpRaven.UnitTests.Integration
             Helper.PrintInfo("Sentry Uri: " + this.ravenClient.CurrentDsn.SentryUri);
             Helper.PrintInfo("Port: " + this.ravenClient.CurrentDsn.Port);
             Helper.PrintInfo("Public Key: " + this.ravenClient.CurrentDsn.PublicKey);
-            Helper.PrintInfo("Private Key: " + this.ravenClient.CurrentDsn.PrivateKey);
             Helper.PrintInfo("Project ID: " + this.ravenClient.CurrentDsn.ProjectID);
 
             await this.ravenClient.CaptureExceptionAsync(Helper.GetException());
@@ -101,7 +99,6 @@ namespace SharpRaven.UnitTests.Integration
             Helper.PrintInfo("Sentry Uri: " + this.ravenClient.CurrentDsn.SentryUri);
             Helper.PrintInfo("Port: " + this.ravenClient.CurrentDsn.Port);
             Helper.PrintInfo("Public Key: " + this.ravenClient.CurrentDsn.PublicKey);
-            Helper.PrintInfo("Private Key: " + this.ravenClient.CurrentDsn.PrivateKey);
             Helper.PrintInfo("Project ID: " + this.ravenClient.CurrentDsn.ProjectID);
 
             await this.ravenClient.CaptureExceptionAsync(Helper.GetException());
@@ -176,7 +173,6 @@ namespace SharpRaven.UnitTests.Integration
             Helper.PrintInfo("Sentry Uri: " + this.ravenClient.CurrentDsn.SentryUri);
             Helper.PrintInfo("Port: " + this.ravenClient.CurrentDsn.Port);
             Helper.PrintInfo("Public Key: " + this.ravenClient.CurrentDsn.PublicKey);
-            Helper.PrintInfo("Private Key: " + this.ravenClient.CurrentDsn.PrivateKey);
             Helper.PrintInfo("Project ID: " + this.ravenClient.CurrentDsn.ProjectID);
 
             await this.ravenClient.CaptureMessageAsync("Test message");
@@ -196,7 +192,6 @@ namespace SharpRaven.UnitTests.Integration
             Helper.PrintInfo("Sentry Uri: " + this.ravenClient.CurrentDsn.SentryUri);
             Helper.PrintInfo("Port: " + this.ravenClient.CurrentDsn.Port);
             Helper.PrintInfo("Public Key: " + this.ravenClient.CurrentDsn.PublicKey);
-            Helper.PrintInfo("Private Key: " + this.ravenClient.CurrentDsn.PrivateKey);
             Helper.PrintInfo("Project ID: " + this.ravenClient.CurrentDsn.ProjectID);
 
             await this.ravenClient.CaptureMessageAsync("Test message");

--- a/src/tests/SharpRaven.UnitTests/Integration/CaptureTests.cs
+++ b/src/tests/SharpRaven.UnitTests/Integration/CaptureTests.cs
@@ -57,7 +57,6 @@ namespace SharpRaven.UnitTests.Integration
             Helper.PrintInfo("Sentry Uri: " + this.ravenClient.CurrentDsn.SentryUri);
             Helper.PrintInfo("Port: " + this.ravenClient.CurrentDsn.Port);
             Helper.PrintInfo("Public Key: " + this.ravenClient.CurrentDsn.PublicKey);
-            Helper.PrintInfo("Private Key: " + this.ravenClient.CurrentDsn.PrivateKey);
             Helper.PrintInfo("Project ID: " + this.ravenClient.CurrentDsn.ProjectID);
         }
 
@@ -79,7 +78,6 @@ namespace SharpRaven.UnitTests.Integration
             Helper.PrintInfo("Sentry Uri: " + this.ravenClient.CurrentDsn.SentryUri);
             Helper.PrintInfo("Port: " + this.ravenClient.CurrentDsn.Port);
             Helper.PrintInfo("Public Key: " + this.ravenClient.CurrentDsn.PublicKey);
-            Helper.PrintInfo("Private Key: " + this.ravenClient.CurrentDsn.PrivateKey);
             Helper.PrintInfo("Project ID: " + this.ravenClient.CurrentDsn.ProjectID);
 
             try
@@ -106,7 +104,6 @@ namespace SharpRaven.UnitTests.Integration
             Helper.PrintInfo("Sentry Uri: " + this.ravenClient.CurrentDsn.SentryUri);
             Helper.PrintInfo("Port: " + this.ravenClient.CurrentDsn.Port);
             Helper.PrintInfo("Public Key: " + this.ravenClient.CurrentDsn.PublicKey);
-            Helper.PrintInfo("Private Key: " + this.ravenClient.CurrentDsn.PrivateKey);
             Helper.PrintInfo("Project ID: " + this.ravenClient.CurrentDsn.ProjectID);
 
             try
@@ -203,7 +200,6 @@ namespace SharpRaven.UnitTests.Integration
             Helper.PrintInfo("Sentry Uri: " + this.ravenClient.CurrentDsn.SentryUri);
             Helper.PrintInfo("Port: " + this.ravenClient.CurrentDsn.Port);
             Helper.PrintInfo("Public Key: " + this.ravenClient.CurrentDsn.PublicKey);
-            Helper.PrintInfo("Private Key: " + this.ravenClient.CurrentDsn.PrivateKey);
             Helper.PrintInfo("Project ID: " + this.ravenClient.CurrentDsn.ProjectID);
 
             this.ravenClient.CaptureMessage("Test message");
@@ -223,7 +219,6 @@ namespace SharpRaven.UnitTests.Integration
             Helper.PrintInfo("Sentry Uri: " + this.ravenClient.CurrentDsn.SentryUri);
             Helper.PrintInfo("Port: " + this.ravenClient.CurrentDsn.Port);
             Helper.PrintInfo("Public Key: " + this.ravenClient.CurrentDsn.PublicKey);
-            Helper.PrintInfo("Private Key: " + this.ravenClient.CurrentDsn.PrivateKey);
             Helper.PrintInfo("Project ID: " + this.ravenClient.CurrentDsn.ProjectID);
 
             Assert.DoesNotThrow(() => this.ravenClient.CaptureMessage("Test message"));


### PR DESCRIPTION
Extract `HttpWebRequest` creation to a separate method to make the `Send()` method across sync and async more DRY and improve logging when the request fails.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-csharp/135)
<!-- Reviewable:end -->
