### PR TITLE
Upped sentry_version from 4 to 7

### DIFF
--- a/src/app/SharpRaven/Utilities/PacketBuilder.cs
+++ b/src/app/SharpRaven/Utilities/PacketBuilder.cs
@@ -37,7 +37,7 @@ namespace SharpRaven.Utilities
     /// </summary>
     public static class PacketBuilder
     {
-        private const int SentryVersion = 4;
+        private const int SentryVersion = 7;
         private static readonly string userAgent;
 
 

--- a/src/tests/SharpRaven.UnitTests/Utilities/PacketBuilderTests.cs
+++ b/src/tests/SharpRaven.UnitTests/Utilities/PacketBuilderTests.cs
@@ -41,7 +41,7 @@ namespace SharpRaven.UnitTests.Utilities
         public void CreateAuthenticationHeader_ReturnsCorrectAuthenticationHeader()
         {
             const string expected =
-                @"^Sentry sentry_version=4, sentry_client=SharpRaven/[\d\.]+, sentry_timestamp=\d+, sentry_key=7d6466e66155431495bdb4036ba9a04b, sentry_secret=4c1cfeab7ebd4c1cb9e18008173a3630$";
+                @"^Sentry sentry_version=[\d], sentry_client=SharpRaven/[\d\.]+, sentry_timestamp=\d+, sentry_key=7d6466e66155431495bdb4036ba9a04b, sentry_secret=4c1cfeab7ebd4c1cb9e18008173a3630$";
 
             var dsn = new Dsn(
                 "https://7d6466e66155431495bdb4036ba9a04b:4c1cfeab7ebd4c1cb9e18008173a3630@app.getsentry.com/3739");


### PR DESCRIPTION
This PR ups the `sentry_version` from 4 to 7. Fixes #133.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-csharp/139)
<!-- Reviewable:end -->
