### PR TITLE
Phone number scrubber fix

### DIFF
--- a/src/app/SharpRaven.Nancy/SharpRaven.Nancy.csproj.DotSettings
+++ b/src/app/SharpRaven.Nancy/SharpRaven.Nancy.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp50</s:String></wpf:ResourceDictionary>

--- a/src/app/SharpRaven/Data/ExceptionData.cs
+++ b/src/app/SharpRaven/Data/ExceptionData.cs
@@ -33,6 +33,8 @@ using System.Collections.Generic;
 
 using Newtonsoft.Json;
 
+using SharpRaven.Utilities;
+
 namespace SharpRaven.Data
 {
     /// <summary>
@@ -62,7 +64,7 @@ namespace SharpRaven.Data
                 }
                 catch (Exception e)
                 {
-                    Console.WriteLine("ERROR: " + e);
+                    SystemUtil.WriteError(e);
                 }
             }
 

--- a/src/app/SharpRaven/Data/RequestData.cs
+++ b/src/app/SharpRaven/Data/RequestData.cs
@@ -1,0 +1,101 @@
+﻿#region License
+
+// Copyright (c) 2014 The Sentry Team and individual contributors.
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification, are permitted
+// provided that the following conditions are met:
+// 
+//     1. Redistributions of source code must retain the above copyright notice, this list of
+//        conditions and the following disclaimer.
+// 
+//     2. Redistributions in binary form must reproduce the above copyright notice, this list of
+//        conditions and the following disclaimer in the documentation and/or other materials
+//        provided with the distribution.
+// 
+//     3. Neither the name of the Sentry nor the names of its contributors may be used to
+//        endorse or promote products derived from this software without specific prior written
+//        permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+// IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+// FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#endregion
+
+using System;
+
+using Newtonsoft.Json;
+
+namespace SharpRaven.Data
+{
+    /// <summary>
+    /// Contains <see cref="string"/> representations of a <see cref="JsonPacket"/>.
+    /// </summary>
+    public class RequestData
+    {
+        private readonly Requester requester;
+        private string formatted;
+        private string raw;
+        private string scrubbed;
+
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RequestData"/> class.
+        /// </summary>
+        /// <param name="requester">The <see cref="Requester"/> in which the request data will be used.</param>
+        internal RequestData(Requester requester)
+        {
+            if (requester == null)
+                throw new ArgumentNullException("requester");
+
+            if (requester.Packet == null)
+                throw new ArgumentException("Requester.Packet was null", "requester");
+
+            this.requester = requester;
+        }
+
+
+        /// <summary>
+        /// Gets the <see cref="JsonPacket"/> converted to a <see cref="System.String"/> before
+        /// being scrubbed by <see cref="SharpRaven.Logging.IScrubber"/>.
+        /// </summary>
+        public string Raw
+        {
+            get { return this.raw = this.raw ?? this.requester.Packet.ToString(Formatting.None); }
+        }
+
+        /// <summary>
+        /// Gets the <see cref="JsonPacket"/> converted to a <see cref="System.String"/> after
+        /// being scrubbed by <see cref="M:IRavenClient.LogScubber"/>. If <see cref="M:IRavenClient.LogScubber"/>
+        /// is null, <see cref="Raw"/> will be returned.
+        /// </summary>
+        public string Scrubbed
+        {
+            get
+            {
+                if (this.requester.Client == null || this.requester.Client.LogScrubber == null)
+                    return Raw;
+
+                return this.scrubbed = this.scrubbed ?? this.requester.Client.LogScrubber.Scrub(Raw);
+            }
+        }
+
+
+        /// <summary>
+        /// Gets a <see cref="System.String"/> representation of the <see cref="RequestData"/>.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="System.String"/> representation of the <see cref="RequestData"/>.
+        /// </returns>
+        public override string ToString()
+        {
+            return this.formatted = this.formatted ?? this.requester.Packet.ToString(Formatting.Indented);
+        }
+    }
+}

--- a/src/app/SharpRaven/Data/Requester.cs
+++ b/src/app/SharpRaven/Data/Requester.cs
@@ -1,0 +1,159 @@
+﻿#region License
+
+// Copyright (c) 2014 The Sentry Team and individual contributors.
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification, are permitted
+// provided that the following conditions are met:
+// 
+//     1. Redistributions of source code must retain the above copyright notice, this list of
+//        conditions and the following disclaimer.
+// 
+//     2. Redistributions in binary form must reproduce the above copyright notice, this list of
+//        conditions and the following disclaimer in the documentation and/or other materials
+//        provided with the distribution.
+// 
+//     3. Neither the name of the Sentry nor the names of its contributors may be used to
+//        endorse or promote products derived from this software without specific prior written
+//        permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+// IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+// FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#endregion
+
+using System;
+using System.IO;
+using System.Net;
+
+using Newtonsoft.Json;
+
+using SharpRaven.Utilities;
+
+namespace SharpRaven.Data
+{
+    /// <summary>
+    /// The class responsible for performing the HTTP request to Sentry.
+    /// </summary>
+    public partial class Requester
+    {
+        private readonly RequestData data;
+        private readonly JsonPacket packet;
+        private readonly RavenClient ravenClient;
+        private readonly HttpWebRequest webRequest;
+
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Requester"/> class.
+        /// </summary>
+        /// <param name="packet">The <see cref="JsonPacket"/> to initialize with.</param>
+        /// <param name="ravenClient">The <see cref="RavenClient"/> to initialize with.</param>
+        internal Requester(JsonPacket packet, RavenClient ravenClient)
+        {
+            if (packet == null)
+                throw new ArgumentNullException("packet");
+
+            if (ravenClient == null)
+                throw new ArgumentNullException("ravenClient");
+
+            this.ravenClient = ravenClient;
+            this.packet = ravenClient.PreparePacket(packet);
+            this.data = new RequestData(this);
+
+            this.webRequest = (HttpWebRequest)System.Net.WebRequest.Create(ravenClient.CurrentDsn.SentryUri);
+            this.webRequest.Timeout = (int)ravenClient.Timeout.TotalMilliseconds;
+            this.webRequest.ReadWriteTimeout = (int)ravenClient.Timeout.TotalMilliseconds;
+            this.webRequest.Method = "POST";
+            this.webRequest.Accept = "application/json";
+            this.webRequest.Headers.Add("X-Sentry-Auth", PacketBuilder.CreateAuthenticationHeader(ravenClient.CurrentDsn));
+            this.webRequest.UserAgent = PacketBuilder.UserAgent;
+
+            if (ravenClient.Compression)
+            {
+                this.webRequest.Headers.Add(HttpRequestHeader.ContentEncoding, "gzip");
+                this.webRequest.AutomaticDecompression = DecompressionMethods.Deflate;
+                this.webRequest.ContentType = "application/octet-stream";
+            }
+            else
+                this.webRequest.ContentType = "application/json; charset=utf-8";
+        }
+
+
+        /// <summary>
+        /// Gets the <see cref="IRavenClient"/>.
+        /// </summary> 
+        public IRavenClient Client
+        {
+            get { return this.ravenClient; }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public RequestData Data
+        {
+            get { return this.data; }
+        }
+
+        /// <summary>
+        /// Gets the <see cref="JsonPacket"/> being sent to Sentry.
+        /// </summary>
+        public JsonPacket Packet
+        {
+            get { return this.packet; }
+        }
+
+        /// <summary>
+        /// Gets the <see cref="HttpWebRequest"/> instance being used to perform the HTTP request to Sentry.
+        /// </summary>
+        public HttpWebRequest WebRequest
+        {
+            get { return this.webRequest; }
+        }
+
+
+        /// <summary>
+        /// Executes the HTTP request to Sentry.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="JsonPacket.EventID" /> of the successfully captured JSON packet, or <c>null</c> if it fails.
+        /// </returns>
+        public string Request()
+        {
+            using (var s = this.webRequest.GetRequestStream())
+            {
+                if (this.ravenClient.Compression)
+                    GzipUtil.Write(this.data.Scrubbed, s);
+                else
+                {
+                    using (var sw = new StreamWriter(s))
+                    {
+                        sw.Write(this.data.Scrubbed);
+                    }
+                }
+            }
+
+            using (var wr = (HttpWebResponse)this.webRequest.GetResponse())
+            {
+                using (var responseStream = wr.GetResponseStream())
+                {
+                    if (responseStream == null)
+                        return null;
+
+                    using (var sr = new StreamReader(responseStream))
+                    {
+                        var content = sr.ReadToEnd();
+                        var response = JsonConvert.DeserializeObject<dynamic>(content);
+                        return response.id;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/app/SharpRaven/Data/SentryRequestFactory.cs
+++ b/src/app/SharpRaven/Data/SentryRequestFactory.cs
@@ -38,6 +38,8 @@ using System.Text;
 
 using Newtonsoft.Json;
 
+using SharpRaven.Utilities;
+
 namespace SharpRaven.Data
 {
     /// <summary>
@@ -90,7 +92,7 @@ namespace SharpRaven.Data
                 }
                 catch (Exception exception)
                 {
-                    Console.WriteLine("An error occurred while retrieving the current HTTP context: {0}", exception);
+                    SystemUtil.WriteError(exception);
                     return null;
                 }
             }
@@ -147,7 +149,7 @@ namespace SharpRaven.Data
             }
             catch (Exception exception)
             {
-                Console.WriteLine(exception);
+                SystemUtil.WriteError(exception);
             }
 
             return null;
@@ -203,7 +205,7 @@ namespace SharpRaven.Data
             }
             catch (Exception exception)
             {
-                Console.WriteLine(exception);
+                SystemUtil.WriteError(exception);
             }
 
             return dictionary;
@@ -242,7 +244,7 @@ namespace SharpRaven.Data
             }
             catch (Exception exception)
             {
-                Console.WriteLine("An error occurred while retrieving the HTTP contextproperty: {0}", exception);
+                SystemUtil.WriteError(exception);
             }
         }
     }

--- a/src/app/SharpRaven/Data/SentryUserFactory.cs
+++ b/src/app/SharpRaven/Data/SentryUserFactory.cs
@@ -31,6 +31,8 @@
 using System;
 using System.Security.Principal;
 
+using SharpRaven.Utilities;
+
 namespace SharpRaven.Data
 {
     /// <summary>
@@ -84,7 +86,7 @@ namespace SharpRaven.Data
             }
             catch (Exception exception)
             {
-                Console.WriteLine(exception);
+                SystemUtil.WriteError(exception);
             }
 
             return null;
@@ -99,7 +101,7 @@ namespace SharpRaven.Data
             }
             catch (Exception exception)
             {
-                Console.WriteLine(exception);
+                SystemUtil.WriteError(exception);
             }
 
             return null;

--- a/src/app/SharpRaven/IRavenClient.cs
+++ b/src/app/SharpRaven/IRavenClient.cs
@@ -43,6 +43,16 @@ namespace SharpRaven
     public interface IRavenClient
     {
         /// <summary>
+        /// Gets or sets the <see cref="Action"/> to execute to manipulate or extract data from
+        /// the <see cref="Requester"/> object before it is used in the <see cref="RavenClient.Send"/> method.
+        /// </summary>
+        /// <value>
+        /// The <see cref="Action"/> to execute to manipulate or extract data from the
+        /// <see cref="Requester"/> object before it is used in the <see cref="RavenClient.Send"/> method.
+        /// </value>
+        Func<Requester, Requester> BeforeSend { get; set; }
+
+        /// <summary>
         /// Enable Gzip Compression?
         /// </summary>
         bool Compression { get; set; }
@@ -56,6 +66,11 @@ namespace SharpRaven
         /// The environment (e.g. production)
         /// </summary>
         string Environment { get; set; }
+
+        /// <summary>
+        /// Not register the <see cref="Breadcrumb"/> for tracking.
+        /// </summary>
+        bool IgnoreBreadcrumbs { get; set; }
 
         /// <summary>
         /// Logger. Default is "root"
@@ -88,13 +103,6 @@ namespace SharpRaven
         /// </value>
         TimeSpan Timeout { get; set; }
 
-        
-        /// <summary>Captures the specified <paramref name="event"/>.</summary>
-        /// <param name="event">The event to capture.</param>
-        /// <returns>
-        /// The <see cref="JsonPacket.EventID" /> of the successfully captured <paramref name="event" />, or <c>null</c> if it fails.
-        /// </returns>
-        string Capture(SentryEvent @event);
 
         /// <summary>
         /// Captures the <see cref="Breadcrumb"/> for tracking.
@@ -102,15 +110,14 @@ namespace SharpRaven
         /// <param name="breadcrumb">The <see cref="Breadcrumb" /> to capture.</param>
         void AddTrail(Breadcrumb breadcrumb);
 
-        /// <summary>
-        /// Restart the capture of the <see cref="Breadcrumb"/> for tracking.
-        /// </summary>
-        void RestartTrails();
 
-        /// <summary>
-        /// Not register the <see cref="Breadcrumb"/> for tracking.
-        /// </summary>
-        bool IgnoreBreadcrumbs { get; set; }
+        /// <summary>Captures the specified <paramref name="event"/>.</summary>
+        /// <param name="event">The event to capture.</param>
+        /// <returns>
+        /// The <see cref="JsonPacket.EventID" /> of the successfully captured <paramref name="event" />, or <c>null</c> if it fails.
+        /// </returns>
+        string Capture(SentryEvent @event);
+
 
         /// <summary>
         /// Captures the <see cref="Exception" />.
@@ -150,6 +157,12 @@ namespace SharpRaven
                               IDictionary<string, string> tags = null,
                               string[] fingerprint = null,
                               object extra = null);
+
+
+        /// <summary>
+        /// Restart the capture of the <see cref="Breadcrumb"/> for tracking.
+        /// </summary>
+        void RestartTrails();
 
 
 #if (!net40)
@@ -223,7 +236,5 @@ namespace SharpRaven
         string CaptureEvent(Exception e, Dictionary<string, string> tags);
 
         #endregion
-
-        
     }
 }

--- a/src/app/SharpRaven/Logging/Filters/PhoneNumberFilter.cs
+++ b/src/app/SharpRaven/Logging/Filters/PhoneNumberFilter.cs
@@ -37,13 +37,23 @@ namespace SharpRaven.Logging.Filters
     /// </summary>
     public class PhoneNumberFilter : IFilter
     {
+        private static readonly Regex phoneRegex;
+
+        /// <summary>
+        /// Static initalization of the <see cref="PhoneNumberFilter"/> class.
+        /// </summary>
+        static PhoneNumberFilter()
+        {
+            phoneRegex = new Regex(@"1?\W*([2-9][0-8][0-9])\W*([2-9][0-9]{2})\W*([0-9]{4})(\se?x?t?(\d*))?");
+        }
+
+
         /// <summary>
         /// An <see cref="IFilter"/> implementation for masking phone numbers in a logged 
         /// </summary>
         public string Filter(string input)
         {
-            Regex phoneRegex = new Regex(@"1?\W*([2-9][0-8][0-9])\W*([2-9][0-9]{2})\W*([0-9]{4})(\se?x?t?(\d*))?");
-            return phoneRegex.Replace(input, delegate { return "##-PHONE-TRUNC-##"; });
+            return phoneRegex.Replace(input, "##-PHONE-TRUNC-##");
         }
     }
 }

--- a/src/app/SharpRaven/Logging/Filters/PhoneNumberFilter.cs
+++ b/src/app/SharpRaven/Logging/Filters/PhoneNumberFilter.cs
@@ -44,7 +44,7 @@ namespace SharpRaven.Logging.Filters
         /// </summary>
         static PhoneNumberFilter()
         {
-            phoneRegex = new Regex(@"1?\W*([2-9][0-8][0-9])\W*([2-9][0-9]{2})\W*([0-9]{4})(\se?x?t?(\d*))?");
+            phoneRegex = new Regex(@"1?\W*([2-9][0-8]\d)\W*([2-9]\d{2})\W*(\d{4})(\se?x?t?(\d*))?\s+", RegexOptions.Compiled);
         }
 
 

--- a/src/app/SharpRaven/RavenClient.cs
+++ b/src/app/SharpRaven/RavenClient.cs
@@ -423,10 +423,10 @@ namespace SharpRaven
                 }
 
                 if (exception != null)
-                    WriteError(exception.ToString());
+                    SystemUtil.WriteError(exception);
 
-                WriteError("Request body:", data);
-                WriteError("Request headers:", request.Headers.ToString());
+                SystemUtil.WriteError("Request body:", data);
+                SystemUtil.WriteError("Request headers:", request.Headers.ToString());
 
                 var webException = exception as WebException;
                 if (webException == null || webException.Response == null)
@@ -449,45 +449,18 @@ namespace SharpRaven
                     }
                 }
 
-                WriteError("Response headers:", response.Headers.ToString());
-                WriteError("Response body:", messageBody);
+                SystemUtil.WriteError("Response headers:", response.Headers.ToString());
+                SystemUtil.WriteError("Response body:", messageBody);
             }
             catch (Exception onErrorException)
             {
-                WriteError(onErrorException.ToString());
+                SystemUtil.WriteError(onErrorException.ToString());
             }
 
             return id;
         }
 
 
-        private static void WriteError(string error)
-        {
-            if (error == null)
-                return;
-
-            Console.ForegroundColor = ConsoleColor.Red;
-            Console.Write("[ERROR] ");
-            Console.ForegroundColor = ConsoleColor.Gray;
-            Console.WriteLine(error);
-        }
-
-
-        private static void WriteError(string description, string multilineData)
-        {
-            if (multilineData == null)
-                return;
-
-            var lines = multilineData.Split(new[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries);
-            if (lines.Length <= 0)
-                return;
-
-            WriteError(description);
-            foreach (var line in lines)
-            {
-                WriteError(line);
-            }
-        }
 
         private IDictionary<string, string> MergeTags(IDictionary<string, string> tags = null)
         {

--- a/src/app/SharpRaven/RavenClient.cs
+++ b/src/app/SharpRaven/RavenClient.cs
@@ -34,8 +34,6 @@ using System.IO;
 using System.Linq;
 using System.Net;
 
-using Newtonsoft.Json;
-
 using SharpRaven.Data;
 using SharpRaven.Logging;
 using SharpRaven.Utilities;
@@ -47,14 +45,14 @@ namespace SharpRaven
     /// </summary>
     public partial class RavenClient : IRavenClient
     {
+        private readonly CircularBuffer<Breadcrumb> breadcrumbs;
         private readonly Dsn currentDsn;
         private readonly IDictionary<string, string> defaultTags;
         private readonly IJsonPacketFactory jsonPacketFactory;
         private readonly ISentryRequestFactory sentryRequestFactory;
         private readonly ISentryUserFactory sentryUserFactory;
 
-        private readonly CircularBuffer<Breadcrumb> breadcrumbs;
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="RavenClient" /> class. Sentry
         /// Data Source Name will be read from sharpRaven section in your app.config or
@@ -107,9 +105,19 @@ namespace SharpRaven
             Logger = "root";
             Timeout = TimeSpan.FromSeconds(5);
             this.defaultTags = new Dictionary<string, string>();
-            breadcrumbs = new CircularBuffer<Breadcrumb>();
+            this.breadcrumbs = new CircularBuffer<Breadcrumb>();
         }
 
+
+        /// <summary>
+        /// Gets or sets the <see cref="Action"/> to execute to manipulate or extract data from
+        /// the <see cref="Requester"/> object before it is used in the <see cref="Send"/> method.
+        /// </summary>
+        /// <value>
+        /// The <see cref="Action"/> to execute to manipulate or extract data from the
+        /// <see cref="Requester"/> object before it is used in the <see cref="Send"/> method.
+        /// </value>
+        public Func<Requester, Requester> BeforeSend { get; set; }
 
         /// <summary>
         /// Gets or sets the <see cref="Action"/> to execute if an error occurs when executing
@@ -175,7 +183,8 @@ namespace SharpRaven
         /// Not register the <see cref="Breadcrumb"/> for tracking.
         /// </summary>
         public bool IgnoreBreadcrumbs { get; set; }
-        
+
+
         /// <summary>
         /// Captures the last 100 <see cref="Breadcrumb" />.
         /// </summary>
@@ -184,9 +193,10 @@ namespace SharpRaven
         {
             if (IgnoreBreadcrumbs || breadcrumb == null)
                 return;
-            
+
             this.breadcrumbs.Add(breadcrumb);
         }
+
 
         /// <summary>
         /// Restart the capture of the <see cref="Breadcrumb"/> for tracking.
@@ -195,6 +205,7 @@ namespace SharpRaven
         {
             this.breadcrumbs.Clear();
         }
+
 
         /// <summary>Captures the specified <paramref name="event"/>.</summary>
         /// <param name="event">The event to capture.</param>
@@ -207,8 +218,8 @@ namespace SharpRaven
                 throw new ArgumentNullException("event");
 
             @event.Tags = MergeTags(@event.Tags);
-            if (!breadcrumbs.IsEmpty())
-                @event.Breadcrumbs = breadcrumbs.ToList();
+            if (!this.breadcrumbs.IsEmpty())
+                @event.Breadcrumbs = this.breadcrumbs.ToList();
 
             var packet = this.jsonPacketFactory.Create(CurrentDsn.ProjectID, @event);
 
@@ -312,16 +323,16 @@ namespace SharpRaven
         /// </summary>
         /// <param name="packet">The prepared <see cref="JsonPacket"/> which has cleared the creation pipeline.</param>
         /// <returns>The <see cref="JsonPacket"/> which should be sent to Sentry.</returns>
-        protected virtual JsonPacket PreparePacket(JsonPacket packet)
+        protected internal virtual JsonPacket PreparePacket(JsonPacket packet)
         {
-            packet.Logger = String.IsNullOrWhiteSpace(packet.Logger)
-                            || (packet.Logger == "root" && !String.IsNullOrWhiteSpace(Logger))
+            packet.Logger = string.IsNullOrWhiteSpace(packet.Logger)
+                            || (packet.Logger == "root" && !string.IsNullOrWhiteSpace(Logger))
                 ? Logger
                 : packet.Logger;
             packet.User = packet.User ?? this.sentryUserFactory.Create();
             packet.Request = packet.Request ?? this.sentryRequestFactory.Create();
-            packet.Release = String.IsNullOrWhiteSpace(packet.Release) ? Release : packet.Release;
-            packet.Environment = String.IsNullOrWhiteSpace(packet.Environment) ? Environment : packet.Environment;
+            packet.Release = string.IsNullOrWhiteSpace(packet.Release) ? Release : packet.Release;
+            packet.Environment = string.IsNullOrWhiteSpace(packet.Environment) ? Environment : packet.Environment;
             return packet;
         }
 
@@ -333,84 +344,25 @@ namespace SharpRaven
         /// </returns>
         protected virtual string Send(JsonPacket packet)
         {
-            string data = null;
-            HttpWebRequest request = null;
+            Requester requester = null;
 
             try
             {
-                request = CreateWebRequest(packet, out data);
+                requester = new Requester(packet, this);
 
-                // Write the messagebody.
-                using (var s = request.GetRequestStream())
-                {
-                    if (Compression)
-                        GzipUtil.Write(data, s);
-                    else
-                    {
-                        using (var sw = new StreamWriter(s))
-                        {
-                            sw.Write(data);
-                        }
-                    }
-                }
+                if (BeforeSend != null)
+                    requester = BeforeSend(requester);
 
-                using (var wr = (HttpWebResponse)request.GetResponse())
-                {
-                    using (var responseStream = wr.GetResponseStream())
-                    {
-                        if (responseStream == null)
-                            return null;
-
-                        using (var sr = new StreamReader(responseStream))
-                        {
-                            var content = sr.ReadToEnd();
-                            var response = JsonConvert.DeserializeObject<dynamic>(content);
-                            return response.id;
-                        }
-                    }
-                }
+                return requester.Request();
             }
             catch (Exception exception)
             {
-                return HandleException(exception, data, request);
+                return HandleException(exception, requester);
             }
         }
 
 
-        private HttpWebRequest CreateWebRequest(JsonPacket packet, out string data)
-        {
-            packet = PreparePacket(packet);
-
-            var request = (HttpWebRequest)WebRequest.Create(this.currentDsn.SentryUri);
-            request.Timeout = (int)Timeout.TotalMilliseconds;
-            request.ReadWriteTimeout = (int)Timeout.TotalMilliseconds;
-            request.Method = "POST";
-            request.Accept = "application/json";
-            request.Headers.Add("X-Sentry-Auth", PacketBuilder.CreateAuthenticationHeader(this.currentDsn));
-            request.UserAgent = PacketBuilder.UserAgent;
-
-            if (Compression)
-            {
-                request.Headers.Add(HttpRequestHeader.ContentEncoding, "gzip");
-                request.AutomaticDecompression = DecompressionMethods.Deflate;
-                request.ContentType = "application/octet-stream";
-            }
-            else
-                request.ContentType = "application/json; charset=utf-8";
-
-            /*string data = packet.ToString(Formatting.Indented);
-                    Console.WriteLine(data);*/
-
-            data = packet.ToString(Formatting.None);
-
-            if (LogScrubber != null)
-                data = LogScrubber.Scrub(data);
-
-            return request;
-        }
-
-
-        private string HandleException(Exception exception, string data, WebRequest request)
+        private string HandleException(Exception exception, Requester requester)
         {
             string id = null;
 
@@ -425,8 +377,17 @@ namespace SharpRaven
                 if (exception != null)
                     SystemUtil.WriteError(exception);
 
-                SystemUtil.WriteError("Request body:", data);
-                SystemUtil.WriteError("Request headers:", request.Headers.ToString());
+                if (requester != null)
+                {
+                    if (requester.Data != null)
+                    {
+                        SystemUtil.WriteError("Request body (raw):", requester.Data.Raw);
+                        SystemUtil.WriteError("Request body (scrubbed):", requester.Data.Scrubbed);
+                    }
+
+                    if (requester.WebRequest != null && requester.WebRequest.Headers != null && requester.WebRequest.Headers.Count > 0)
+                        SystemUtil.WriteError("Request headers:", requester.WebRequest.Headers.ToString());
+                }
 
                 var webException = exception as WebException;
                 if (webException == null || webException.Response == null)
@@ -434,7 +395,7 @@ namespace SharpRaven
 
                 var response = webException.Response;
                 id = response.Headers["X-Sentry-ID"];
-                if (String.IsNullOrWhiteSpace(id))
+                if (string.IsNullOrWhiteSpace(id))
                     id = null;
 
                 string messageBody;
@@ -461,13 +422,12 @@ namespace SharpRaven
         }
 
 
-
         private IDictionary<string, string> MergeTags(IDictionary<string, string> tags = null)
         {
             if (tags == null)
-                return this.defaultTags;
+                return Tags;
 
-            return this.defaultTags
+            return Tags
                 .Where(kv => !tags.Keys.Contains(kv.Key))
                 .Concat(tags)
                 .ToDictionary(kv => kv.Key, kv => kv.Value);

--- a/src/app/SharpRaven/SharpRaven.csproj
+++ b/src/app/SharpRaven/SharpRaven.csproj
@@ -95,6 +95,9 @@
     <Compile Include="Data\ErrorLevel.cs" />
     <Compile Include="Data\ExceptionFrame.cs" />
     <Compile Include="Data\IJsonPacketFactory.cs" />
+    <Compile Include="Data\RequestData.cs" />
+    <Compile Include="Data\Requester.Net45.cs" />
+    <Compile Include="Data\Requester.cs" />
     <Compile Include="Data\SentryEvent.cs" />
     <Compile Include="Data\SentryMessage.cs" />
     <Compile Include="Data\SentryException.cs" />

--- a/src/app/SharpRaven/SharpRaven.csproj.DotSettings
+++ b/src/app/SharpRaven/SharpRaven.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp50</s:String></wpf:ResourceDictionary>

--- a/src/app/SharpRaven/Utilities/SystemUtil.cs
+++ b/src/app/SharpRaven/Utilities/SystemUtil.cs
@@ -48,10 +48,10 @@ namespace SharpRaven.Utilities
         public static IDictionary<string, string> GetModules()
         {
             var assemblies = AppDomain.CurrentDomain
-                                      .GetAssemblies()
-                                      .Where(q => !q.IsDynamic)
-                                      .Select(a => a.GetName())
-                                      .OrderBy(a => a.Name);
+                .GetAssemblies()
+                .Where(q => !q.IsDynamic)
+                .Select(a => a.GetName())
+                .OrderBy(a => a.Name);
 
             var dictionary = new Dictionary<string, string>();
 
@@ -64,6 +64,54 @@ namespace SharpRaven.Utilities
             }
 
             return dictionary;
+        }
+
+        /// <summary>
+        /// Writes the <paramref name="exception"/> to the <see cref="Console"/>.
+        /// </summary>
+        /// <param name="exception">The <see cref="Exception"/> to write to the <see cref="Console"/>.</param>
+        public static void WriteError(Exception exception)
+        {
+            if (exception == null)
+                return;
+
+            WriteError(exception.ToString());
+        }
+
+        /// <summary>
+        /// Writes the <paramref name="error"/> to the <see cref="Console"/>.
+        /// </summary>
+        /// <param name="error">The error to write to the <see cref="Console"/>.</param>
+        public static void WriteError(string error)
+        {
+            if (error == null)
+                return;
+
+            Console.ForegroundColor = ConsoleColor.Red;
+            Console.Write("[ERROR] ");
+            Console.ForegroundColor = ConsoleColor.Gray;
+            Console.WriteLine(error);
+        }
+
+        /// <summary>
+        /// Writes the <paramref name="description"/> and <paramref name="multilineData"/> to the <see cref="Console"/>.
+        /// </summary>
+        /// <param name="description">The text describing the <paramref name="multilineData"/>.</param>
+        /// <param name="multilineData">The multi-line data to write to the <see cref="Console"/>.</param>
+        public static void WriteError(string description, string multilineData)
+        {
+            if (multilineData == null)
+                return;
+
+            var lines = multilineData.Split(new[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries);
+            if (lines.Length <= 0)
+                return;
+
+            WriteError(description);
+            foreach (var line in lines)
+            {
+                WriteError(line);
+            }
         }
     }
 }

--- a/src/tests/SharpRaven.Nancy.UnitTests/SharpRaven.Nancy.UnitTests.csproj.DotSettings
+++ b/src/tests/SharpRaven.Nancy.UnitTests/SharpRaven.Nancy.UnitTests.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp50</s:String></wpf:ResourceDictionary>

--- a/src/tests/SharpRaven.UnitTests/Logging/CreditCardFilterTests.cs
+++ b/src/tests/SharpRaven.UnitTests/Logging/CreditCardFilterTests.cs
@@ -38,16 +38,16 @@ namespace SharpRaven.UnitTests.Logging
     public class CreditCardFilterTests : FilterTestsBase<CreditCardFilter>
     {
         [Test]
-        public void InvalidCreditCardNumber_IsNotScrubbed()
+        public void MatchingCreditCardNumber_IsScrubbed()
         {
-            InvalidValueIsNotScrubbed("1234-5678-9101-1121");
+            MatchingValueIsScrubbed("5271-1902-4264-3112");
         }
 
 
         [Test]
-        public void ValidCreditCardNumber_IsScrubbed()
+        public void NonMatchingCreditCardNumber_IsNotScrubbed()
         {
-            ValidValueIsScrubbed("5271-1902-4264-3112");
+            NonMatchingValueIsNotScrubbed("1234-5678-9101-1121");
         }
     }
 }

--- a/src/tests/SharpRaven.UnitTests/Logging/FilterTestsBase.cs
+++ b/src/tests/SharpRaven.UnitTests/Logging/FilterTestsBase.cs
@@ -28,8 +28,6 @@
 
 #endregion
 
-using System;
-
 using NUnit.Framework;
 
 using SharpRaven.Logging;
@@ -48,9 +46,15 @@ namespace SharpRaven.UnitTests.Logging
         }
 
 
-        protected void InvalidValueIsNotScrubbed(string invalidValue)
+        protected TFilter Filter
         {
-            var input = String.Format(
+            get { return this.filter; }
+        }
+
+
+        protected void NonMatchingValueIsNotScrubbed(string invalidValue)
+        {
+            var input = string.Format(
                 "Lorem ipsum dolor sit amet, consectetur adipiscing elit. {0} Praesent est dui, ornare eget condimentum a, tincidunt sit amet lectus. Nulla pellentesque, tortor eget tempus malesuada.",
                 invalidValue);
 
@@ -60,9 +64,9 @@ namespace SharpRaven.UnitTests.Logging
         }
 
 
-        protected void ValidValueIsScrubbed(string validValue)
+        protected void MatchingValueIsScrubbed(string validValue)
         {
-            var input = String.Format(
+            var input = string.Format(
                 "Lorem ipsum dolor sit amet, consectetur adipiscing elit. {0} Praesent est dui, ornare eget condimentum a, tincidunt sit amet lectus. Nulla pellentesque, tortor eget tempus malesuada.",
                 validValue);
 

--- a/src/tests/SharpRaven.UnitTests/Logging/LogScrubberTests.cs
+++ b/src/tests/SharpRaven.UnitTests/Logging/LogScrubberTests.cs
@@ -104,7 +104,7 @@ namespace SharpRaven.UnitTests.Logging
 
 
         [Test]
-        public void ValidValues_AreScrubbed()
+        public void MatchingValues_AreScrubbed()
         {
             const string validCreditCardNumber = "5271-1902-4264-3112";
             const string validPhoneNumber = "55518231234";

--- a/src/tests/SharpRaven.UnitTests/Logging/PhoneNumberFilterTests.cs
+++ b/src/tests/SharpRaven.UnitTests/Logging/PhoneNumberFilterTests.cs
@@ -38,23 +38,28 @@ namespace SharpRaven.UnitTests.Logging
     public class PhoneNumberFilterTests : FilterTestsBase<PhoneNumberFilter>
     {
         [Test]
-        public void InvalidPhoneNumber_IsNotScrubbed()
+        public void JsonKeyContainingPhoneNumber_IsNotScrubbed()
         {
-            InvalidValueIsNotScrubbed("1531");
+            const string json =
+                @"{""culprit"":""SharpRaven.UnitTests.Helper in FirstLevelException"",""event_id55518231234e2400d82f11c490683c2d2"",""exception"":[],""user"": {""username"":""asbjornu""}}";
+
+            var output = Filter.Filter(json);
+
+            Assert.That(output, Is.StringContaining("event_id55518231234e2400d82f11c490683c2d2"));
         }
 
 
         [Test]
-        public void ValidPhoneNumber_IsScrubbed()
+        public void MatchingPhoneNumber_IsScrubbed()
         {
-            ValidValueIsScrubbed("55518231234");
+            MatchingValueIsScrubbed("55518231234");
         }
 
 
         [Test]
-        public void PhoneNumberContainingJson_IsNotScrubbed()
+        public void NonMatchingPhoneNumber_IsNotScrubbed()
         {
-            InvalidValueIsNotScrubbed("\":\"55518231234");
+            NonMatchingValueIsNotScrubbed("1531");
         }
     }
 }

--- a/src/tests/SharpRaven.UnitTests/Logging/SocialSecurityFilterTests.cs
+++ b/src/tests/SharpRaven.UnitTests/Logging/SocialSecurityFilterTests.cs
@@ -39,16 +39,16 @@ namespace SharpRaven.UnitTests.Logging
     public class SocialSecurityFilterTests : FilterTestsBase<SocialSecurityFilter>
     {
         [Test]
-        public void InvalidSocialSecurityNumber_IsNotScrubbed()
+        public void MatchingSocialSecurityNumber_IsScrubbed()
         {
-            InvalidValueIsNotScrubbed("1531");
+            MatchingValueIsScrubbed("55518231234");
         }
 
 
         [Test]
-        public void ValidSocialSecurityNumber_IsScrubbed()
+        public void NonMatchingSocialSecurityNumber_IsNotScrubbed()
         {
-            ValidValueIsScrubbed("55518231234");
+            NonMatchingValueIsNotScrubbed("1531");
         }
     }
 }

--- a/src/tests/SharpRaven.UnitTests/RavenClientTests/CaptureAsyncTests.cs
+++ b/src/tests/SharpRaven.UnitTests/RavenClientTests/CaptureAsyncTests.cs
@@ -110,9 +110,9 @@ namespace SharpRaven.UnitTests.RavenClientTests
 
 
         [Test]
-        public void ScrubberIsInvoked()
+        public async void ScrubberIsInvoked()
         {
-            this.tester.ScrubberIsInvoked(async (client, message) => await client.CaptureAsync(new SentryEvent(message)));
+            await this.tester.ScrubberIsInvokedAsync(async (client, message) => await client.CaptureAsync(new SentryEvent(message)));
         }
 
 

--- a/src/tests/SharpRaven.UnitTests/RavenClientTests/CaptureExceptionAsyncTests.cs
+++ b/src/tests/SharpRaven.UnitTests/RavenClientTests/CaptureExceptionAsyncTests.cs
@@ -108,9 +108,9 @@ namespace SharpRaven.UnitTests.RavenClientTests
 
 
         [Test]
-        public void ScrubberIsInvoked()
+        public async void ScrubberIsInvoked()
         {
-            this.tester.ScrubberIsInvoked(async (client, message) => await client.CaptureExceptionAsync(new Exception(message)));
+            await this.tester.ScrubberIsInvokedAsync(async (client, message) => await client.CaptureExceptionAsync(new Exception(message)));
         }
 
 

--- a/src/tests/SharpRaven.UnitTests/RavenClientTests/CaptureMessageAsyncTests.cs
+++ b/src/tests/SharpRaven.UnitTests/RavenClientTests/CaptureMessageAsyncTests.cs
@@ -106,9 +106,9 @@ namespace SharpRaven.UnitTests.RavenClientTests
 
 
         [Test]
-        public void ScrubberIsInvoked()
+        public async void ScrubberIsInvoked()
         {
-            this.tester.ScrubberIsInvoked(async (client, message) => await client.CaptureMessageAsync(message));
+            await this.tester.ScrubberIsInvokedAsync(async (client, message) => await client.CaptureMessageAsync(message));
         }
 
 

--- a/src/tests/SharpRaven.UnitTests/SharpRaven.UnitTests.csproj.DotSettings
+++ b/src/tests/SharpRaven.UnitTests/SharpRaven.UnitTests.csproj.DotSettings
@@ -1,2 +1,3 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp50</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=MethodPropertyEvent/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb_AaBb" /&gt;</s:String></wpf:ResourceDictionary>

--- a/src/tests/SharpRaven.WebTest/SharpRaven.WebTest.csproj.DotSettings
+++ b/src/tests/SharpRaven.WebTest/SharpRaven.WebTest.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/CSharpLanguageProject/LanguageLevel/@EntryValue">CSharp50</s:String></wpf:ResourceDictionary>


### PR DESCRIPTION
This PR does a lot of things to improve logging in order to make debugging issues like the one it tries to fix easier:

- Moves the `WriteError()` methods from `RavenClient` to `SystemUtil` and replaces all usage of `Console.WriteLine()` in error conditions with `SystemUtil.WriteError()` (5e973891305ced4a5ccda23f5d09a1ea42b79118).
- Sets the ReSharper language level to version 5 of the language, to avoid (automatic) code upgrades to C# 6 (	5865964934bb8d53f261d7034a95473b1f548ce0).
- Adds a `Requester` and moves all request related logic from RavenClient to it. Also adds a  `Func<>` called `RavenClient.BeforeSend` so the `Requester` is exposed and can be manipulated before the HTTP request is performed. Finally adds a `RequestData` class to capture the HTTP body in scrubbed and raw variants to simplify debugging and logging (73f83c23f65f302380ecf2c65a9512a2d9726acb).
- Finally tries to fix the phone number filtering to avoid [problems like these](http://teamcity.codebetter.com/viewLog.html?buildId=225422&tab=buildResultsDiv&buildTypeId=bt1000).

The problem, as made evident in the TeamCity build log, is that the phone number filter somehow makes the JSON invalid, as can be seen here (look for `event_id`):

```
[ERROR] System.Net.WebException: The remote server returned an error: (400) Bad Request.
   at System.Net.HttpWebRequest.GetResponse()
   at SharpRaven.RavenClient.Send(JsonPacket packet) in z:\TeamCityAgent\work\e7d71061a519bcfc\src\app\SharpRaven\RavenClient.cs:line 357
[ERROR] Request body:
[ERROR] {"culprit":"SharpRaven.UnitTests.Helper in FirstLevelException","event_id##-PHONE-TRUNC-##1d429c87bdee3426f23050","exception":[{"module":"SharpRaven.UnitTests","stacktrace":{"frames":[{"abs_path":null,"colno":17,"filename":"z:\\TeamCityAgent\\work\\e7d71061a519bcfc\\src\\tests\\SharpRaven.UnitTests\\Helper.cs","function":"FirstLevelException","in_app":false,"lineno":47,"module":"SharpRaven.UnitTests.Helper","post_context":null,"pre_context":null,"context_line":"Void FirstLevelException()","vars":null},{"abs_path":null,"colno":17,"filename":"z:\\TeamCityAgent\\work\\e7d71061a519bcfc\\src\\tests\\SharpRaven.UnitTests\\Integration\\CaptureTests.cs","function":"CaptureException_WithStacktrace_ReturnsValidID","in_app":false,"lineno":166,"module":"SharpRaven.UnitTests.Integration.CaptureTests","post_context":null,"pre_context":null,"context_line":"Void CaptureException_WithStacktrace_ReturnsValidID()","vars":null}]},"type":"Exception","value":"First Level Exception"},{"module":"SharpRaven.UnitTests","stacktrace":{"frames":[{"abs_path":null,"colno":17,"filename":"z:\\TeamCityAgent\\work\\e7d71061a519bcfc\\src\\tests\\SharpRaven.UnitTests\\Helper.cs","function":"SecondLevelException","in_app":false,"lineno":97,"module":"SharpRaven.UnitTests.Helper","post_context":null,"pre_context":null,"context_line":"Void SecondLevelException()","vars":null},{"abs_path":null,"colno":17,"filename":"z:\\TeamCityAgent\\work\\e7d71061a519bcfc\\src\\tests\\SharpRaven.UnitTests\\Helper.cs","function":"FirstLevelException","in_app":false,"lineno":41,"module":"SharpRaven.UnitTests.Helper","post_context":null,"pre_context":null,"context_line":"Void FirstLevelException()","vars":null}]},"type":"InvalidOperationException","value":"Second Level Exception"},{"module":"SharpRaven.UnitTests","stacktrace":{"frames":[{"abs_path":null,"colno":13,"filename":"z:\\TeamCityAgent\\work\\e7d71061a519bcfc\\src\\tests\\SharpRaven.UnitTests\\Helper.cs","function":"PerformDivideByZero","in_app":false,"lineno":79,"module":"SharpRaven.UnitTests.Helper","post_context":null,"pre_context":null,"context_line":"Void PerformDivideByZero()","vars":null},{"abs_path":null,"colno":17,"filename":"z:\\TeamCityAgent\\work\\e7d71061a519bcfc\\src\\tests\\SharpRaven.UnitTests\\Helper.cs","function":"SecondLevelException","in_app":false,"lineno":87,"module":"SharpRaven.UnitTests.Helper","post_context":null,"pre_context":null,"context_line":"Void SecondLevelException()","vars":null}]},"type":"DivideByZeroException","value":"Attempted to divide by zero."}],"extra":{"extra":"EXTRA1","FirstLevelExceptionKey":"FirstLevelExceptionValue","System.InvalidOperationException.Data":{"InvalidOperationExceptionKey":"InvalidOperationExceptionValue","System.DivideByZeroException.Data":{"DivideByZeroKey":"DivideByZeroValue"}}},"fingerprint":[],"level":"error","logger":"C#","message":"First Level Exception","sentry.interfaces.Message":{"message":"First Level Exception"},"modules":{"JetBrains.BuildServer.CommonLoggers":"10.0.91.0","JetBrains.BuildServer.NUnitLauncher-NUnit-2.6.4-plugin":"10.0.91.0","JetBrains.TeamCity.TestRunnerCommon":"10.0.91.0","JetBrains.TeamCity.Utils":"10.0.91.0","Microsoft.CSharp":"4.0.0.0","mscorlib":"4.0.0.0","Newtonsoft.Json":"6.0.0.0","NSubstitute":"1.8.0.0","nunit.core":"2.6.4.14350","nunit.core.interfaces":"2.6.4.14350","nunit.framework":"2.6.4.14350","nunit.util":"2.6.4.14350","SharpRaven":"2.1.1.0","SharpRaven.UnitTests":"2.1.1.0","System":"4.0.0.0","System.ComponentModel.DataAnnotations":"4.0.0.0","System.Configuration":"4.0.0.0","System.Core":"4.0.0.0","System.Data":"4.0.0.0","System.DirectoryServices.Protocols":"4.0.0.0","System.Drawing":"4.0.0.0","System.Dynamic":"4.0.0.0","System.Numerics":"4.0.0.0","System.Runtime.Serialization":"4.0.0.0","System.ServiceModel":"4.0.0.0","System.Web":"4.0.0.0","System.Web.ApplicationServices":"4.0.0.0","System.Xml":"4.0.0.0","System.Xml.Linq":"4.0.0.0"},"platform":"csharp","project":"3739","server_name":"WIN-OJ3LCVAVSG3","tags":{"TAG":"TAG1"},"timestamp":"2016-08-15T09:48:15.4570079Z","user":{"username":"SYSTEM"}}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-csharp/140)
<!-- Reviewable:end -->
