### PR TITLE
Feature public sentryevent.tags

### DIFF
--- a/src/tests/SharpRaven.UnitTests/Data/SentryEventTests.cs
+++ b/src/tests/SharpRaven.UnitTests/Data/SentryEventTests.cs
@@ -1,0 +1,77 @@
+﻿#region License
+
+// Copyright (c) 2014 The Sentry Team and individual contributors.
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification, are permitted
+// provided that the following conditions are met:
+// 
+//     1. Redistributions of source code must retain the above copyright notice, this list of
+//        conditions and the following disclaimer.
+// 
+//     2. Redistributions in binary form must reproduce the above copyright notice, this list of
+//        conditions and the following disclaimer in the documentation and/or other materials
+//        provided with the distribution.
+// 
+//     3. Neither the name of the Sentry nor the names of its contributors may be used to
+//        endorse or promote products derived from this software without specific prior written
+//        permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+// IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+// FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#endregion
+
+using System;
+
+using NUnit.Framework;
+
+using SharpRaven.Data;
+
+namespace SharpRaven.UnitTests.Data
+{
+    [TestFixture]
+    public class SentryEventTests
+    {
+        [Test]
+        public void ShouldWhenConstructorTagsNotNull()
+        {
+            Assert.That(new SentryEvent(new Exception("foo")).Tags, Is.Not.Null);
+        }
+
+        [Test]
+        public void ShouldNotNullDictionaryWhenAssignNullForTags()
+        {
+            var sentryEvent = new SentryEvent(new Exception("foo")) { Tags = null};
+
+            Assert.That(sentryEvent.Tags, Is.Not.Null);
+        }
+
+        [Test]
+        public void ShouldTheSameDictionaryFromConstructor()
+        {
+            var sentryEvent = new SentryEvent(new Exception("foo"));
+            var beforeDictionary = sentryEvent.Tags;
+
+            Assert.That(beforeDictionary, Is.SameAs(sentryEvent.Tags));
+        }
+
+        [Test]
+        public void ShouldStartNewDictionaryWhenAsignNullForTags()
+        {
+            var sentryEvent = new SentryEvent(new Exception("foo"));
+            var beforeDictionary = sentryEvent.Tags;
+
+            sentryEvent.Tags = null;
+
+            Assert.That(beforeDictionary, Is.Not.SameAs(sentryEvent.Tags));
+        }
+
+    }
+}

--- a/src/tests/SharpRaven.UnitTests/SharpRaven.UnitTests.csproj
+++ b/src/tests/SharpRaven.UnitTests/SharpRaven.UnitTests.csproj
@@ -81,6 +81,7 @@
     <Compile Include="Data\HttpRequestBodyConverterTests.cs" />
     <Compile Include="Data\JsonPacketFactoryTests.cs" />
     <Compile Include="Data\BreadcrumbsRecordTests.cs" />
+    <Compile Include="Data\SentryEventTests.cs" />
     <Compile Include="Data\JsonPacketTests.cs" />
     <Compile Include="Data\SentryExceptionTests.cs" />
     <Compile Include="Data\SentryMessageTests.cs" />


### PR DESCRIPTION
Complementing the PR #149. Some tests case to ensure public assign from SentryEvent.Tags

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-csharp/159)
<!-- Reviewable:end -->
