### PR TITLE
Demangle Anonymous Function Names

### DIFF
--- a/src/tests/SharpRaven.UnitTests/Data/ExceptionFrameTests.cs
+++ b/src/tests/SharpRaven.UnitTests/Data/ExceptionFrameTests.cs
@@ -133,5 +133,16 @@ namespace SharpRaven.UnitTests.Data
             Assert.AreEqual(frame.Function, "EditVrByJson");
             Assert.AreEqual(frame.Module, "Flipdish.Domain.DomainModel.Services.RestaurantService");
         }
+
+        [Test]
+        public void Contructor_Demangles_Lambdas()
+        {
+            var module = "Example.Module";
+
+            Assert.AreEqual("BeginInvokeAsynchronousActionMethod { <lambda> }", MockStackFrame(module, "<BeginInvokeAsynchronousActionMethod>b__36").Function);
+            Assert.AreEqual("InvokeActionMethodFilterAsynchronouslyRecursive { <lambda> }", MockStackFrame(module, "<InvokeActionMethodFilterAsynchronouslyRecursive>b__3d").Function);
+            Assert.AreEqual("BeginInvokeAction { <lambda> }", MockStackFrame(module, "<BeginInvokeAction>b__1e").Function);
+
+        }
     }
 }


### PR DESCRIPTION
Demangle compiler generated function names for anonymous functions and
replace with something more readable.

Change:

```
<BeginInvokeAsynchronousActionMethod>b__36
```

to:

```
BeginInvokeAsynchronousActionMethod { λ }
```

Fixes #147
