### PR TITLE
Added user injection to SentryEvent. Also added offline caching of jsonpackets

### DIFF
--- a/src/SharpRaven.sln
+++ b/src/SharpRaven.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.40629.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SharpRaven", "app\SharpRaven\SharpRaven.csproj", "{CC80A2E1-AE39-44DE-8DA3-4EEF42F90FB1}"
 EndProject
@@ -161,6 +161,12 @@ Global
 		{156621FC-2C48-4CDF-A368-9347BABE9089}.Release 4.5|Mixed Platforms.ActiveCfg = Release 4.5|Any CPU
 		{156621FC-2C48-4CDF-A368-9347BABE9089}.Release 4.5|Mixed Platforms.Build.0 = Release 4.5|Any CPU
 		{156621FC-2C48-4CDF-A368-9347BABE9089}.Release 4.5|x86.ActiveCfg = Release 4.5|Any CPU
+		{ABE22746-6EEB-4970-A608-C02BC3B8BDA3}.Debug 3.5|Any CPU.ActiveCfg = Debug 4.5|Any CPU
+		{ABE22746-6EEB-4970-A608-C02BC3B8BDA3}.Debug 3.5|Any CPU.Build.0 = Debug 4.5|Any CPU
+		{ABE22746-6EEB-4970-A608-C02BC3B8BDA3}.Debug 3.5|Mixed Platforms.ActiveCfg = Debug 4.5|Any CPU
+		{ABE22746-6EEB-4970-A608-C02BC3B8BDA3}.Debug 3.5|Mixed Platforms.Build.0 = Debug 4.5|Any CPU
+		{ABE22746-6EEB-4970-A608-C02BC3B8BDA3}.Debug 3.5|x86.ActiveCfg = Debug 4.5|Any CPU
+		{ABE22746-6EEB-4970-A608-C02BC3B8BDA3}.Debug 3.5|x86.Build.0 = Debug 4.5|Any CPU
 		{ABE22746-6EEB-4970-A608-C02BC3B8BDA3}.Debug 4.0|Any CPU.ActiveCfg = Debug 4.0|Any CPU
 		{ABE22746-6EEB-4970-A608-C02BC3B8BDA3}.Debug 4.0|Any CPU.Build.0 = Debug 4.0|Any CPU
 		{ABE22746-6EEB-4970-A608-C02BC3B8BDA3}.Debug 4.0|Mixed Platforms.ActiveCfg = Debug 4.0|Any CPU
@@ -171,6 +177,12 @@ Global
 		{ABE22746-6EEB-4970-A608-C02BC3B8BDA3}.Debug 4.5|Mixed Platforms.ActiveCfg = Debug 4.5|Any CPU
 		{ABE22746-6EEB-4970-A608-C02BC3B8BDA3}.Debug 4.5|Mixed Platforms.Build.0 = Debug 4.5|Any CPU
 		{ABE22746-6EEB-4970-A608-C02BC3B8BDA3}.Debug 4.5|x86.ActiveCfg = Debug 4.5|Any CPU
+		{ABE22746-6EEB-4970-A608-C02BC3B8BDA3}.Release 3.5|Any CPU.ActiveCfg = Release 4.5|Any CPU
+		{ABE22746-6EEB-4970-A608-C02BC3B8BDA3}.Release 3.5|Any CPU.Build.0 = Release 4.5|Any CPU
+		{ABE22746-6EEB-4970-A608-C02BC3B8BDA3}.Release 3.5|Mixed Platforms.ActiveCfg = Release 4.5|Any CPU
+		{ABE22746-6EEB-4970-A608-C02BC3B8BDA3}.Release 3.5|Mixed Platforms.Build.0 = Release 4.5|Any CPU
+		{ABE22746-6EEB-4970-A608-C02BC3B8BDA3}.Release 3.5|x86.ActiveCfg = Release 4.5|Any CPU
+		{ABE22746-6EEB-4970-A608-C02BC3B8BDA3}.Release 3.5|x86.Build.0 = Release 4.5|Any CPU
 		{ABE22746-6EEB-4970-A608-C02BC3B8BDA3}.Release 4.0|Any CPU.ActiveCfg = Release 4.0|Any CPU
 		{ABE22746-6EEB-4970-A608-C02BC3B8BDA3}.Release 4.0|Any CPU.Build.0 = Release 4.0|Any CPU
 		{ABE22746-6EEB-4970-A608-C02BC3B8BDA3}.Release 4.0|Mixed Platforms.ActiveCfg = Release 4.0|Any CPU
@@ -181,6 +193,12 @@ Global
 		{ABE22746-6EEB-4970-A608-C02BC3B8BDA3}.Release 4.5|Mixed Platforms.ActiveCfg = Release 4.5|Any CPU
 		{ABE22746-6EEB-4970-A608-C02BC3B8BDA3}.Release 4.5|Mixed Platforms.Build.0 = Release 4.5|Any CPU
 		{ABE22746-6EEB-4970-A608-C02BC3B8BDA3}.Release 4.5|x86.ActiveCfg = Release 4.5|Any CPU
+		{7FE52A2B-430C-4C6F-BEA9-0855AF973D0C}.Debug 3.5|Any CPU.ActiveCfg = Debug 4.5|Any CPU
+		{7FE52A2B-430C-4C6F-BEA9-0855AF973D0C}.Debug 3.5|Any CPU.Build.0 = Debug 4.5|Any CPU
+		{7FE52A2B-430C-4C6F-BEA9-0855AF973D0C}.Debug 3.5|Mixed Platforms.ActiveCfg = Debug 4.5|Any CPU
+		{7FE52A2B-430C-4C6F-BEA9-0855AF973D0C}.Debug 3.5|Mixed Platforms.Build.0 = Debug 4.5|Any CPU
+		{7FE52A2B-430C-4C6F-BEA9-0855AF973D0C}.Debug 3.5|x86.ActiveCfg = Debug 4.5|Any CPU
+		{7FE52A2B-430C-4C6F-BEA9-0855AF973D0C}.Debug 3.5|x86.Build.0 = Debug 4.5|Any CPU
 		{7FE52A2B-430C-4C6F-BEA9-0855AF973D0C}.Debug 4.0|Any CPU.ActiveCfg = Debug 4.0|Any CPU
 		{7FE52A2B-430C-4C6F-BEA9-0855AF973D0C}.Debug 4.0|Any CPU.Build.0 = Debug 4.0|Any CPU
 		{7FE52A2B-430C-4C6F-BEA9-0855AF973D0C}.Debug 4.0|Mixed Platforms.ActiveCfg = Debug 4.0|Any CPU
@@ -191,6 +209,12 @@ Global
 		{7FE52A2B-430C-4C6F-BEA9-0855AF973D0C}.Debug 4.5|Mixed Platforms.ActiveCfg = Debug 4.5|Any CPU
 		{7FE52A2B-430C-4C6F-BEA9-0855AF973D0C}.Debug 4.5|Mixed Platforms.Build.0 = Debug 4.5|Any CPU
 		{7FE52A2B-430C-4C6F-BEA9-0855AF973D0C}.Debug 4.5|x86.ActiveCfg = Debug 4.5|Any CPU
+		{7FE52A2B-430C-4C6F-BEA9-0855AF973D0C}.Release 3.5|Any CPU.ActiveCfg = Release 4.5|Any CPU
+		{7FE52A2B-430C-4C6F-BEA9-0855AF973D0C}.Release 3.5|Any CPU.Build.0 = Release 4.5|Any CPU
+		{7FE52A2B-430C-4C6F-BEA9-0855AF973D0C}.Release 3.5|Mixed Platforms.ActiveCfg = Release 4.5|Any CPU
+		{7FE52A2B-430C-4C6F-BEA9-0855AF973D0C}.Release 3.5|Mixed Platforms.Build.0 = Release 4.5|Any CPU
+		{7FE52A2B-430C-4C6F-BEA9-0855AF973D0C}.Release 3.5|x86.ActiveCfg = Release 4.5|Any CPU
+		{7FE52A2B-430C-4C6F-BEA9-0855AF973D0C}.Release 3.5|x86.Build.0 = Release 4.5|Any CPU
 		{7FE52A2B-430C-4C6F-BEA9-0855AF973D0C}.Release 4.0|Any CPU.ActiveCfg = Release 4.0|Any CPU
 		{7FE52A2B-430C-4C6F-BEA9-0855AF973D0C}.Release 4.0|Any CPU.Build.0 = Release 4.0|Any CPU
 		{7FE52A2B-430C-4C6F-BEA9-0855AF973D0C}.Release 4.0|Mixed Platforms.ActiveCfg = Release 4.0|Any CPU

--- a/src/app/SharpRaven/Data/Breadcrumb.cs
+++ b/src/app/SharpRaven/Data/Breadcrumb.cs
@@ -9,6 +9,7 @@ namespace SharpRaven.Data {
     /// <summary>
     /// Breadcrumb trail.
     /// </summary>
+    [Serializable]
     public class Breadcrumb {
         private readonly DateTime timestamp;
 

--- a/src/app/SharpRaven/Data/IJsonPacketFactory.cs
+++ b/src/app/SharpRaven/Data/IJsonPacketFactory.cs
@@ -59,7 +59,8 @@ namespace SharpRaven.Data
                           ErrorLevel level = ErrorLevel.Info,
                           IDictionary<string, string> tags = null,
                           string[] fingerprint = null,
-                          object extra = null);
+                          object extra = null,
+                          string user = null);
 
 
         /// <summary>
@@ -84,7 +85,8 @@ namespace SharpRaven.Data
                           ErrorLevel level = ErrorLevel.Error,
                           IDictionary<string, string> tags = null,
                           string[] fingerprint = null,
-                          object extra = null);
+                          object extra = null,
+                          string user = null);
 
 
         /// <summary>

--- a/src/app/SharpRaven/Data/JsonPacket.cs
+++ b/src/app/SharpRaven/Data/JsonPacket.cs
@@ -32,7 +32,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-
+using System.Runtime.Serialization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -44,6 +44,7 @@ namespace SharpRaven.Data
     /// <summary>
     /// Represents the JSON packet that is transmitted to Sentry.
     /// </summary>
+    [Serializable]
     public class JsonPacket
     {
         /// <summary>
@@ -395,6 +396,11 @@ namespace SharpRaven.Data
                     Exceptions.Add(sentryException);
                 }
             }
+        }
+
+        public override int GetHashCode()
+        {
+            return this.ToString().GetHashCode()*17;
         }
     }
 }

--- a/src/app/SharpRaven/Data/JsonPacket.cs
+++ b/src/app/SharpRaven/Data/JsonPacket.cs
@@ -397,10 +397,5 @@ namespace SharpRaven.Data
                 }
             }
         }
-
-        public override int GetHashCode()
-        {
-            return this.ToString().GetHashCode()*17;
-        }
     }
 }

--- a/src/app/SharpRaven/Data/JsonPacketFactory.cs
+++ b/src/app/SharpRaven/Data/JsonPacketFactory.cs
@@ -59,14 +59,16 @@ namespace SharpRaven.Data
                                  ErrorLevel level = ErrorLevel.Info,
                                  IDictionary<string, string> tags = null,
                                  string[] fingerprint = null,
-                                 object extra = null)
+                                 object extra = null,
+                                 string user = null)
         {
             var @event = new SentryEvent(message)
             {
                 Level = level,
                 Extra = extra,
                 Tags = tags,
-                Fingerprint = fingerprint
+                Fingerprint = fingerprint,
+                User = user
             };
 
             return Create(project, @event);
@@ -87,6 +89,7 @@ namespace SharpRaven.Data
         /// <param name="tags">The tags to annotate the captured <paramref name="exception" /> with.</param>
         /// <param name="fingerprint">The custom fingerprint to annotate the captured <paramref name="message" /> with.</param>
         /// <param name="extra">The extra metadata to send with the captured <paramref name="exception" />.</param>
+        /// <param name="user"></param>
         /// <returns>
         /// A new instance of
         /// <see cref="JsonPacket" /> for the specified
@@ -101,7 +104,8 @@ namespace SharpRaven.Data
                                  ErrorLevel level = ErrorLevel.Error,
                                  IDictionary<string, string> tags = null,
                                  string[] fingerprint = null,
-                                 object extra = null)
+                                 object extra = null,
+                                 string user = null)
         {
             var @event = new SentryEvent(exception)
             {
@@ -110,6 +114,7 @@ namespace SharpRaven.Data
                 Extra = extra,
                 Tags = tags,
                 Fingerprint = fingerprint,
+                User = user
             };
 
             return Create(project, @event);
@@ -130,8 +135,10 @@ namespace SharpRaven.Data
         {
             var json = new JsonPacket(project, @event)
             {
-                Breadcrumbs = @event.Breadcrumbs
+                Breadcrumbs = @event.Breadcrumbs,
             };
+
+            if(!string.IsNullOrEmpty(@event.User)) json.User = new SentryUser(@event.User);
 
             return OnCreate(json);
         }

--- a/src/app/SharpRaven/Data/Requester.cs
+++ b/src/app/SharpRaven/Data/Requester.cs
@@ -66,6 +66,9 @@ namespace SharpRaven.Data
             if (ravenClient == null)
                 throw new ArgumentNullException("ravenClient");
 
+            if (ravenClient.CurrentDsn.SentryUri == null)
+                throw new InvalidOperationException("SentryUri was null");
+
             this.ravenClient = ravenClient;
             this.packet = ravenClient.PreparePacket(packet);
             this.data = new RequestData(this);

--- a/src/app/SharpRaven/Data/SentryEvent.cs
+++ b/src/app/SharpRaven/Data/SentryEvent.cs
@@ -36,19 +36,22 @@ namespace SharpRaven.Data
     /// <summary>
     /// Represents an event being captured by <see cref="IRavenClient.Capture(SentryEvent)"/>.
     /// </summary>
+    [Serializable]
     public class SentryEvent
     {
         private readonly Exception exception;
         private IList<string> fingerprint;
         private SentryMessage message;
         private IDictionary<string, string> tags;
-
+        public string User;
 
         /// <summary>Initializes a new instance of the <see cref="SentryEvent" /> class.</summary>
         /// <param name="exception">The <see cref="Exception" /> to capture.</param>
-        public SentryEvent(Exception exception)
+        /// <param name="user"></param>
+        public SentryEvent(Exception exception, string user = null)
             : this()
         {
+            this.User = user;
             this.exception = exception;
             Level = ErrorLevel.Error;
         }
@@ -56,9 +59,11 @@ namespace SharpRaven.Data
 
         /// <summary>Initializes a new instance of the <see cref="SentryEvent"/> class.</summary>
         /// <param name="message">The message to capture.</param>
-        public SentryEvent(SentryMessage message)
+        /// <param name="user"></param>
+        public SentryEvent(SentryMessage message, string user = null)
             : this()
         {
+            this.User = user;
             Message = message;
         }
 

--- a/src/app/SharpRaven/Data/SentryException.cs
+++ b/src/app/SharpRaven/Data/SentryException.cs
@@ -38,6 +38,7 @@ namespace SharpRaven.Data
     /// <summary>
     /// Represents Sentry's version of an <see cref="Exception"/>.
     /// </summary>
+    [Serializable]
     public class SentryException
     {
         private readonly string message;

--- a/src/app/SharpRaven/Data/SentryMessage.cs
+++ b/src/app/SharpRaven/Data/SentryMessage.cs
@@ -39,6 +39,7 @@ namespace SharpRaven.Data
     /// Captures a <see cref="string"/> message, optionally formatted with arguments,
     /// as sent to Sentry.
     /// </summary>
+    [Serializable]
     public class SentryMessage
     {
         private readonly string message;

--- a/src/app/SharpRaven/Data/SentryUser.cs
+++ b/src/app/SharpRaven/Data/SentryUser.cs
@@ -28,6 +28,7 @@
 
 #endregion
 
+using System;
 using System.Security.Principal;
 
 using Newtonsoft.Json;
@@ -38,6 +39,7 @@ namespace SharpRaven.Data
     /// An interface which describes the authenticated User for a request.
     /// You should provide at least either an id (a unique identifier for an authenticated user) or ip_address (their IP address).
     /// </summary>
+    [Serializable]
     public class SentryUser
     {
         /// <summary>

--- a/src/app/SharpRaven/SharpRaven.csproj
+++ b/src/app/SharpRaven/SharpRaven.csproj
@@ -156,6 +156,7 @@
     <Compile Include="Configuration.cs" />
     <Compile Include="Utilities\CircularBuffer.cs" />
     <Compile Include="Utilities\GzipUtil.cs" />
+    <Compile Include="Utilities\Serializer.cs" />
     <Compile Include="Utilities\PacketBuilder.cs" />
     <Compile Include="Utilities\SystemUtil.cs" />
   </ItemGroup>

--- a/src/app/SharpRaven/Utilities/Serializer.cs
+++ b/src/app/SharpRaven/Utilities/Serializer.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.Serialization.Formatters.Binary;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SharpRaven.Utilities
+{
+    public static class Serializer
+    {
+        public static byte[] SerialiseBytes(this object obj)
+        {
+            using (var stream = new MemoryStream())
+            {
+                var formatter = new BinaryFormatter();
+                formatter.Serialize(stream, obj);
+                return stream.ToArray();
+            }
+        }
+
+        public static T DeserialiseBytes<T>(this byte[] buffer)
+        {
+            if (buffer == null || buffer.Length <= 0) throw new ArgumentException("Attempted to deserialise an empty array", "buffer");
+            using (var stream = new MemoryStream(buffer))
+            {
+                var result = (T)new BinaryFormatter().Deserialize(stream);
+                return result;
+            }
+        }
+    }
+}

--- a/src/app/SharpRaven/Utilities/Serializer.cs
+++ b/src/app/SharpRaven/Utilities/Serializer.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace SharpRaven.Utilities
 {

--- a/src/app/SharpRaven/Utilities/Serializer.cs
+++ b/src/app/SharpRaven/Utilities/Serializer.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Linq;
 using System.Runtime.Serialization.Formatters.Binary;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace SharpRaven.Utilities
 {


### PR DESCRIPTION
I updated the constructor of the SentryEvent to accept and optional User field. If it is populated the user is injected into the jsonPacket. If it is null or empty the original code is executed and the username is populated from the currently logged in user.

I also added offline caching of packets to a .json file if no internet connection is available. Next time the client is initialised the packets are sent to the server.

The message field is updated to include the UTC time of which the packet send failed previously. This is done every time the client is loaded.

The concept could be easily be expanded to take a serialiser class that allows the missed packets to be stored differently. It currently meets my own requirements, though you may wish to refactor/improve it.

edit: Automated compile suggests compile error on the unit tests, I did not edit these classes so not sure what the deal is there.