### PR TITLE
Feature:  Submit User Feedback for an Event

### DIFF
--- a/src/app/SharpRaven/Data/Requester.Net45.cs
+++ b/src/app/SharpRaven/Data/Requester.Net45.cs
@@ -81,6 +81,35 @@ namespace SharpRaven.Data
                 }
             }
         }
+
+        /// <summary>
+        /// Sends the user feedback asynchronously to sentry
+        /// </summary>
+        /// <returns>An empty string if succesful, otherwise the server response</returns>
+        public async Task<string> SendFeedbackAsync()
+        {
+            using (var s = await this.webRequest.GetRequestStreamAsync())
+            {
+                using (var sw = new StreamWriter(s))
+                {
+                    await sw.WriteAsync(feedback.ToString());
+                }
+            }
+            using (var wr = (HttpWebResponse)await this.webRequest.GetResponseAsync())
+            {
+                using (var responseStream = wr.GetResponseStream())
+                {
+                    if (responseStream == null)
+                        return null;
+
+                    using (var sr = new StreamReader(responseStream))
+                    {
+                        var response = await sr.ReadToEndAsync();
+                        return response;
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/src/app/SharpRaven/Data/SentryUserFeedback.cs
+++ b/src/app/SharpRaven/Data/SentryUserFeedback.cs
@@ -1,0 +1,92 @@
+﻿#region License
+
+// Copyright (c) 2014 The Sentry Team and individual contributors.
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification, are permitted
+// provided that the following conditions are met:
+// 
+//     1. Redistributions of source code must retain the above copyright notice, this list of
+//        conditions and the following disclaimer.
+// 
+//     2. Redistributions in binary form must reproduce the above copyright notice, this list of
+//        conditions and the following disclaimer in the documentation and/or other materials
+//        provided with the distribution.
+// 
+//     3. Neither the name of the Sentry nor the names of its contributors may be used to
+//        endorse or promote products derived from this software without specific prior written
+//        permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+// IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+// FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+using System.Text;
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+#if net35
+using System.Web;
+#endif
+
+namespace SharpRaven.Data
+{
+    /// <summary>
+    /// Represents the UserFeedback that is transmitted to Sentry
+    /// </summary>
+    public class SentryUserFeedback
+    {
+        /// <summary>
+        /// The name associated with this feedback
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The email associated with this feedback
+        /// </summary>
+        public string Email { get; set; }
+
+        /// <summary>
+        /// The comments associated with this feedback
+        /// </summary>
+        public string Comments { get; set; }
+
+        /// <summary>
+        /// The event ID associated with this feedback
+        /// </summary>
+        public string EventID {get; set;}
+
+        /// <summary>
+        /// Returns the url request string for this user feedback
+        /// </summary>
+        /// <returns>A <see cref="System.String"/> that represents the url request string for this <see cref="SharpRaven.Data.SentryUserFeedback"/>.</returns>
+        public override string ToString()
+        {
+			return string.Format("eventId={0}&name={1}&email={2}&comments={3}",
+#if net35
+                                 HttpUtility.UrlEncode(EventID),
+                                 HttpUtility.UrlEncode(Name),
+                                 HttpUtility.UrlEncode(Email),
+                                 HttpUtility.UrlEncode(Comments));
+#elif net40
+                                 WebUtility.HtmlEncode(EventID),
+                                 WebUtility.HtmlEncode(Name),
+                                 WebUtility.HtmlEncode(Email),
+                                 WebUtility.HtmlEncode(Comments));
+#else
+                                 WebUtility.UrlEncode(EventID), 
+			                     WebUtility.UrlEncode(Name), 
+			                     WebUtility.UrlEncode(Email), 
+			                     WebUtility.UrlEncode(Comments));
+#endif
+        }
+    }
+}
+

--- a/src/app/SharpRaven/Dsn.cs
+++ b/src/app/SharpRaven/Dsn.cs
@@ -45,6 +45,7 @@ namespace SharpRaven
         private readonly string projectID;
         private readonly string publicKey;
         private readonly Uri sentryUri;
+        private readonly Uri feedbackUri;
         private readonly Uri uri;
 
 
@@ -71,6 +72,12 @@ namespace SharpRaven
                                                     Path,
                                                     ProjectID);
                 this.sentryUri = new Uri(sentryUriString);
+                var feedbackUriString = String.Format("{0}://{1}:{2}{3}/api/embed/error-page/",
+                                                        this.uri.Scheme,
+                                                        this.uri.DnsSafeHost,
+                                                        Port,
+                                                        Path);
+                this.feedbackUri = new Uri(feedbackUriString);
             }
             catch (Exception exception)
             {
@@ -125,6 +132,14 @@ namespace SharpRaven
         public Uri SentryUri
         {
             get { return this.sentryUri; }
+        }
+
+        /// <summary>
+        /// The Sentry Uri for sending user feedback
+        /// </summary>
+        public Uri FeedbackUri
+        {
+            get { return this.feedbackUri; }
         }
 
         /// <summary>

--- a/src/app/SharpRaven/RavenClient.Net45.cs
+++ b/src/app/SharpRaven/RavenClient.Net45.cs
@@ -154,6 +154,28 @@ namespace SharpRaven
                 return HandleException(exception, requester);
             }
         }
+
+		/// <summary>Sends the specified user feedback to Sentry</summary>
+		/// <returns>An empty string if succesful, otherwise the server response</returns>
+		/// <param name="feedback">The user feedback to send</param>
+        public async Task<string> SendUserFeedbackAsync(SentryUserFeedback feedback)
+        {
+            Requester requester = null;
+
+            try
+            {
+                requester = new Requester(feedback, this);
+
+                if (BeforeSend != null)
+                    requester = BeforeSend(requester);
+
+                return await requester.SendFeedbackAsync();
+            }
+            catch (Exception exception)
+            {
+                return HandleException(exception, requester);
+            } 
+        }
     }
 }
 

--- a/src/app/SharpRaven/RavenClient.cs
+++ b/src/app/SharpRaven/RavenClient.cs
@@ -230,6 +230,7 @@ namespace SharpRaven
         }
 
 
+
         /// <summary>
         /// Captures the event.
         /// </summary>
@@ -365,6 +366,28 @@ namespace SharpRaven
             {
                 return HandleException(exception, requester);
             }
+        }
+
+		/// <summary>Sends the specified user feedback to Sentry</summary>
+		/// <returns>An empty string if succesful, otherwise the server response</returns>
+		/// <param name="feedback">The user feedback to send</param>
+        public string SendUserFeedback(SentryUserFeedback feedback)
+        {
+            Requester requester = null;
+
+            try
+            {
+                requester = new Requester(feedback, this);
+
+                if (BeforeSend != null)
+                    requester = BeforeSend(requester);
+
+                return requester.SendFeedback();
+            }
+            catch (Exception exception)
+            {
+                return HandleException(exception, requester);
+            } 
         }
 
 

--- a/src/app/SharpRaven/SharpRaven.csproj
+++ b/src/app/SharpRaven/SharpRaven.csproj
@@ -140,6 +140,7 @@
     <Compile Include="Data\SentryRequestFactory.cs" />
     <Compile Include="Data\SentryStacktrace.cs" />
     <Compile Include="Data\SentryUser.cs" />
+    <Compile Include="Data\SentryUserFeedback.cs" />
     <Compile Include="Dsn.cs" />
     <Compile Include="Data\JsonPacket.cs" />
     <Compile Include="IRavenClient.cs" />


### PR DESCRIPTION
This PR adds support for submitting user feedback to Sentry as mentioned in #150.
The feedback form post API endpoint is used, which is undocumented, so
it is possible this may break. However the endpoint has been stable for
the past 7 months or so.

**Notes**:

* The sentry form post API endpoint is found at `https://<sentry url>/api/embed/error-page/?dsn=<dsn>&eventId=<eventId>&name=<name>&email=<email>&comments=<comments>`
* All form fields must be filled out (name, email, comments), and each user feedback must have
an associated eventId
* There is an official API for submitting User Feedback (see [https://docs.sentry.io/api/projects/post-project-user-reports/](https://docs.sentry.io/api/projects/post-project-user-reports/)), however it requires an API key rather than just a Dsn, and so is a little more cumbersome to use.

**Example Usage**:

Here `sentryClient` is a `RavenClient`, and we have already submitted an event and saved the ID in `eventID`.

```
var res = sentryClient.SendUserFeedback(new SentryUserFeedback
    { 
        Name = "Example Name", 
        Email = "Example.Email@null.com", 
        Comments = "This is an example comment.\nMultiline comments should be supported!", 
        EventID = eventID
    });
```
----

**Changes**:

Add the SentryUserFeedback class which holds the feedback information
(Name, Email, Comment, EventID)

Modify the Requester class:

* Add a user feedback specific constructor, which takes a
SentryUserFeedback

* Add the CreateWebRequest method, which takes a URI and returns an
HttpWebRequest object with the boilerplate information setup (timeout,
authorization etc.). This reduces copy-and-pasting code between the two
constructors

* Add the SendFeedback method, which sends the user feedback to Sentry

Modify the Requester.Net45 class:

* Add the SendFeedbackAsync method, which sends the user feedback to
Sentry asynchronously

Modify the RavenClient class:

* Add the SendUserFeedback method, which takes a SentryUserFeedback,
creates the Requester object for the feedback, and sends it to Sentry

Modify the RavenClient.Net45 class:

* Add the SendUserFeedbackAsync method, which does the same job as the
SendUserFeedback method, but asynchronously

Modify the Dsn class:

* Add the FeedbackUri property, which is the user feedback form
submission endpoint