### PR TITLE
Fixed NoOpRavenClient dsn

### DIFF
--- a/src/app/SharpRaven/NoOpRavenClient.cs
+++ b/src/app/SharpRaven/NoOpRavenClient.cs
@@ -49,7 +49,7 @@ namespace SharpRaven
         /// </summary>
         public NoOpRavenClient()
         {
-            currentDsn = new Dsn("http://sentry-dsn.invalid");
+            currentDsn = new Dsn("http://ig:nore@sentry-dsn.invalid");
             defaultTags = new Dictionary<string, string>();
         }
 


### PR DESCRIPTION
Changed NoOpRavenClient DSN from `http://sentry-dsn.invalid to` `http://ig:nore@sentry-dsn.invalid` so the Dns class constructor won't throw an exception, originating from the below from Dns.cs. 

```c#
private static string GetPrivateKey(Uri uri)
        {
            return uri.UserInfo.Split(':')[1];
        }
```

Although that also can throw a more meaningful exception.

Fixes #230.