### PR TITLE
Private key is not longer required for DSN

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,7 +30,7 @@ Instantiate the client with your DSN:
 
 .. sourcecode:: csharp
 
-    var ravenClient = new RavenClient("___DSN___");
+    var ravenClient = new RavenClient("___PUBLIC_DSN___");
 
 Capturing Exceptions
 --------------------
@@ -106,7 +106,7 @@ The only thing you have to do is provide a DSN, either by registering an instanc
 
     protected override void ApplicationStartup(TinyIoCContainer container, IPipelines pipelines)
     {
-        container.Register(new Dsn("http://public@example.com/project-id"));
+        container.Register(new Dsn("___PUBLIC_DSN___"));
     }
 
 or through configuration:
@@ -118,7 +118,7 @@ or through configuration:
         <section name="sharpRaven" type="SharpRaven.Nancy.NancyConfiguration, SharpRaven.Nancy" />
       </configSections>
       <sharpRaven>
-        <dsn value="http://public@example.com/project-id" />
+        <dsn value="___PUBLIC_DSN___" />
       </sharpRaven>
     </configuration>
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -106,7 +106,7 @@ The only thing you have to do is provide a DSN, either by registering an instanc
 
     protected override void ApplicationStartup(TinyIoCContainer container, IPipelines pipelines)
     {
-        container.Register(new Dsn("http://public:secret@example.com/project-id"));
+        container.Register(new Dsn("http://public@example.com/project-id"));
     }
 
 or through configuration:
@@ -118,7 +118,7 @@ or through configuration:
         <section name="sharpRaven" type="SharpRaven.Nancy.NancyConfiguration, SharpRaven.Nancy" />
       </configSections>
       <sharpRaven>
-        <dsn value="http://public:secret@example.com/project-id" />
+        <dsn value="http://public@example.com/project-id" />
       </sharpRaven>
     </configuration>
 

--- a/src/app/SharpRaven/Dsn.cs
+++ b/src/app/SharpRaven/Dsn.cs
@@ -61,7 +61,7 @@ namespace SharpRaven
             {
                 this.uri = new Uri(dsn);
                 this.privateKey = GetPrivateKey(this.uri);
-                this.publicKey = GetPublicKey(this.uri);
+                this.publicKey = GetPublicKey(this.uri) ?? throw new ArgumentException("A publicKey is required.", nameof(dsn));
                 this.port = this.uri.Port;
                 this.projectID = GetProjectID(this.uri);
                 this.path = GetPath(this.uri);
@@ -176,13 +176,14 @@ namespace SharpRaven
 
 
         /// <summary>
-        /// Get a private key from a Dsn uri.
+        /// Get a private key or null if no private key defined.
         /// </summary>
         /// <param name="uri"></param>
         /// <returns></returns>
         private static string GetPrivateKey(Uri uri)
         {
-            return uri.UserInfo.Split(':')[1];
+            var parts = uri.UserInfo.Split(':');
+            return parts.Length == 2 ? parts[1] : null;
         }
 
 
@@ -205,7 +206,8 @@ namespace SharpRaven
         /// <returns></returns>
         private static string GetPublicKey(Uri uri)
         {
-            return uri.UserInfo.Split(':')[0];
+            var publicKey = uri.UserInfo.Split(':')[0];
+            return publicKey != string.Empty ? publicKey : null;
         }
     }
 }

--- a/src/app/SharpRaven/Utilities/PacketBuilder.cs
+++ b/src/app/SharpRaven/Utilities/PacketBuilder.cs
@@ -78,12 +78,12 @@ namespace SharpRaven.Utilities
                                  + ", sentry_client={1}"
                                  + ", sentry_timestamp={2}"
                                  + ", sentry_key={3}"
-                                 + ", sentry_secret={4}",
+                                 + "{4}",
                                  SentryVersion,
                                  UserAgent,
                                  (long)(DateTime.UtcNow - new DateTime(1970, 1, 1)).TotalSeconds,
                                  dsn.PublicKey,
-                                 dsn.PrivateKey);
+                                 dsn.PrivateKey != null ? ", sentry_secret=" + dsn.PrivateKey : null);
         }
     }
 }

--- a/src/tests/SharpRaven.UnitTests/DsnTests.cs
+++ b/src/tests/SharpRaven.UnitTests/DsnTests.cs
@@ -74,12 +74,40 @@ namespace SharpRaven.UnitTests
 
 
         [Test]
+        public void Constructor_ValidDsnWithoutPrivateKey_PrivateKeyGetterReturnsNull()
+        {
+            var dsn = new Dsn(TestHelper.DsnUriWithoutPrivateKey);
+
+            Assert.That(dsn.PrivateKey, Is.Null);
+        }
+
+
+        [Test]
+        public void Constructor_ValidDsnWithoutPrivateKey_PublicKeyIsParsed()
+        {
+            var dsn = new Dsn(TestHelper.DsnUriWithoutPrivateKey);
+
+            Assert.AreEqual("7d6466e66155431495bdb4036ba9a04b", dsn.PublicKey);
+        }
+
+
+        [Test]
         public void Constructor_ValidHttpsUri_UriIsEqualToDsn()
         {
             var dsn = new Dsn(TestHelper.DsnUri);
 
             Assert.That(dsn.Uri, Is.Not.Null);
             Assert.That(dsn.Uri.ToString(), Is.EqualTo(TestHelper.DsnUri));
+        }
+
+
+        [Test]
+        public void Constructor_ValidDsnWithoutPrivateKey_UriIsEqualToDsn()
+        {
+            var dsn = new Dsn(TestHelper.DsnUriWithoutPrivateKey);
+
+            Assert.That(dsn.Uri, Is.Not.Null);
+            Assert.That(dsn.Uri.ToString(), Is.EqualTo(TestHelper.DsnUriWithoutPrivateKey));
         }
 
 

--- a/src/tests/SharpRaven.UnitTests/Utilities/PacketBuilderTests.cs
+++ b/src/tests/SharpRaven.UnitTests/Utilities/PacketBuilderTests.cs
@@ -38,13 +38,27 @@ namespace SharpRaven.UnitTests.Utilities
     public class PacketBuilderTests
     {
         [Test]
-        public void CreateAuthenticationHeader_ReturnsCorrectAuthenticationHeader()
+        public void CreateAuthenticationHeader_DsnWithSecret_ReturnsCorrectAuthenticationHeader()
         {
             const string expected =
                 @"^Sentry sentry_version=[\d], sentry_client=SharpRaven/[\d\.]+, sentry_timestamp=\d+, sentry_key=7d6466e66155431495bdb4036ba9a04b, sentry_secret=4c1cfeab7ebd4c1cb9e18008173a3630$";
 
             var dsn = new Dsn(
                 "https://7d6466e66155431495bdb4036ba9a04b:4c1cfeab7ebd4c1cb9e18008173a3630@app.getsentry.com/3739");
+
+            var authenticationHeader = PacketBuilder.CreateAuthenticationHeader(dsn);
+
+            Assert.That(authenticationHeader, Is.StringMatching(expected));
+        }
+
+        [Test]
+        public void CreateAuthenticationHeader_DsnWithoutSecret_ReturnsCorrectAuthenticationHeader()
+        {
+            const string expected =
+                @"^Sentry sentry_version=[\d], sentry_client=SharpRaven/[\d\.]+, sentry_timestamp=\d+, sentry_key=7d6466e66155431495bdb4036ba9a04b$";
+
+            var dsn = new Dsn(
+                "https://7d6466e66155431495bdb4036ba9a04b@app.getsentry.com/3739");
 
             var authenticationHeader = PacketBuilder.CreateAuthenticationHeader(dsn);
 

--- a/src/tests/SharpRaven.UnitTests/Utilities/TestHelper.cs
+++ b/src/tests/SharpRaven.UnitTests/Utilities/TestHelper.cs
@@ -39,6 +39,9 @@ namespace SharpRaven.UnitTests.Utilities
         public const string DsnUri =
             "https://7d6466e66155431495bdb4036ba9a04b:4c1cfeab7ebd4c1cb9e18008173a3630@app.getsentry.com/3739";
 
+        public const string DsnUriWithoutPrivateKey =
+          "https://7d6466e66155431495bdb4036ba9a04b@app.getsentry.com/3739";
+
 
         public static Exception GetException()
         {


### PR DESCRIPTION
The private DSNs (including secret keys) will be officially deprecated soon. This PR allows users to specify a public DSN and makes sure the sentry_secret is not included in the header anymore. For backwards compatibility, a private DSN can still be used, though.