### PR TITLE
Tests pass on macOS

### DIFF
--- a/src/app/SharpRaven/Data/Context/Device.cs
+++ b/src/app/SharpRaven/Data/Context/Device.cs
@@ -30,6 +30,9 @@
 
 using System;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text;
+
 using Newtonsoft.Json;
 using SharpRaven.Serialization;
 using SharpRaven.Utilities;
@@ -208,13 +211,18 @@ namespace SharpRaven.Data.Context
         internal static string GetArchitecture() =>
 #if HAS_RUNTIME_INFORMATION
                    // x-plat: Known results: X86, X64, Arm, Arm64,
-                   System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture.ToString();
+                   RuntimeInformation.ProcessArchitecture.ToString();
 #else
                    // Windows: Known results: AMD64, IA64, x86
                    Environment.GetEnvironmentVariable("PROCESSOR_ARCHITECTURE", EnvironmentVariableTarget.Machine)
                    // Unix: Known results: i686, i386, x86_64, aarch64 (Target Machine is unsupported on Mono outside Windows)
-                   ?? Environment.GetEnvironmentVariable("HOSTTYPE", EnvironmentVariableTarget.Process);
+                   ?? Environment.GetEnvironmentVariable("HOSTTYPE", EnvironmentVariableTarget.Process)
+    #if !NET35
+                   // https://github.com/mono/mono/blob/cdea795c0e4706abee0841174c35799690f63ccb/mcs/class/corlib/System.Runtime.InteropServices.RuntimeInformation/RuntimeInformation.cs
+                   ?? (Environment.Is64BitProcess ? "X64" : "X86");
+    #else
+                   ?? (IntPtr.Size == 4 ? "X86" : "X64");
+    #endif
 #endif
-
     }
 }

--- a/src/app/SharpRaven/SharpRaven.csproj
+++ b/src/app/SharpRaven/SharpRaven.csproj
@@ -16,6 +16,7 @@
     <PackageProjectUrl>https://github.com/getsentry/raven-csharp</PackageProjectUrl>
     <RepositoryUrl>https://github.com/getsentry/raven-csharp.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
+    <LangVersion>7.1</LangVersion>
   </PropertyGroup>
 
   <Import Project="..\..\CommonConfigurations.targets" />
@@ -36,7 +37,11 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net45'">
     <Reference Include="System.Net.Http" />
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net45'">
+    <DefineConstants>HAS_RUNTIME_INFORMATION;$(AdditionalConstants)</DefineConstants>
+  </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net471'">
     <Reference Include="System" />

--- a/src/app/SharpRaven/Utilities/EntryAssemblyNameLocator.cs
+++ b/src/app/SharpRaven/Utilities/EntryAssemblyNameLocator.cs
@@ -23,9 +23,9 @@ namespace SharpRaven.Utilities
 
             try
             {
-                entryAssemblyName = 
+                entryAssemblyName =
                     // Fastest/Simpler API but returns null when entry is unmanaged code
-                    Assembly.GetEntryAssembly()?.GetName() 
+                    Assembly.GetEntryAssembly()?.GetName()
                     ?? GetAssemblyNameFromEntryMethod();
             }
             catch (Exception e)
@@ -68,8 +68,8 @@ namespace SharpRaven.Utilities
                     break;
                 }
 
-                if (method.Name == "InvokeMethod"
-                    && method.DeclaringType == typeof(RuntimeMethodHandle))
+                if (method.Name == "InvokeMethod" && method.DeclaringType == typeof(RuntimeMethodHandle)
+                    || method.Name == "InternalInvoke" && method.DeclaringType?.Name == "MonoMethod")
                 {
                     entryMethod = i == 0
                         ? method

--- a/src/app/SharpRaven/Utilities/RuntimeInfoHelper.cs
+++ b/src/app/SharpRaven/Utilities/RuntimeInfoHelper.cs
@@ -2,8 +2,6 @@
 using System.Reflection;
 #if HAS_RUNTIME_INFORMATION
 using System.Runtime.InteropServices;
-#elif NET45
-using Microsoft.Win32;
 #endif
 
 namespace SharpRaven.Utilities
@@ -17,11 +15,6 @@ namespace SharpRaven.Utilities
             // https://github.com/dotnet/corefx/blob/master/src/System.Runtime.InteropServices.RuntimeInformation/src/System/Runtime/InteropServices/RuntimeInformation/RuntimeInformation.cs
             // e.g: .NET Framework 4.7.2633.0, .NET Native, WebAssembly
             var version = RuntimeInformation.FrameworkDescription;
-#elif NET45
-            var mono = GetFromMono();
-            var version = mono
-                // Windows only: Get latest installation of .NET Framework 4.5 or later
-                ?? Get45PlusLatestInstallationFromRegistry();
 #else
             var mono = GetFromMono();
             var version = mono
@@ -49,45 +42,5 @@ namespace SharpRaven.Utilities
 
             return monoVersion;
         }
-
-        // Only Windows, .NET Framework 4.5 forward
-#if NET45
-        // https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed#to-find-net-framework-versions-by-querying-the-registry-in-code-net-framework-45-and-later
-        private static string Get45PlusLatestInstallationFromRegistry()
-        {
-            const string subkey = @"SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full\";
-
-            try
-            {
-                using (var ndpKey = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32).OpenSubKey(subkey))
-                {
-                    return int.TryParse(ndpKey?.GetValue("Release")?.ToString(), out var releaseId)
-                        ? $".NET Framework {GetFor45PlusVersion(releaseId)}"
-                        : null;
-                }
-            }
-            catch (PlatformNotSupportedException)
-            {
-                return null;
-            }
-
-            string GetFor45PlusVersion(int releaseKey)
-            {
-                switch (releaseKey)
-                {
-                    // NOTE: 4.7.1 and forward support netstandard 2.0 and should use a different API!
-                    case int _ when releaseKey >= 461308: return $"4.7.1 or higher ({releaseKey})";
-                    case int _ when releaseKey >= 460798: return "4.7";
-                    case int _ when releaseKey >= 394802: return "4.6.2";
-                    case int _ when releaseKey >= 394254: return "4.6.1";
-                    case int _ when releaseKey >= 393295: return "4.6";
-                    case int _ when releaseKey >= 379893: return "4.5.2";
-                    case int _ when releaseKey >= 378675: return "4.5.1";
-                    case int _ when releaseKey >= 378389: return "4.5";
-                    default: return null;
-                }
-            }
-        }
-#endif
     }
 }

--- a/src/tests/SharpRaven.UnitTests/Data/Context/AppTests.cs
+++ b/src/tests/SharpRaven.UnitTests/Data/Context/AppTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 
 using Newtonsoft.Json;
 using NUnit.Framework;

--- a/src/tests/SharpRaven.UnitTests/Data/Context/DeviceTests.cs
+++ b/src/tests/SharpRaven.UnitTests/Data/Context/DeviceTests.cs
@@ -58,14 +58,14 @@ namespace SharpRaven.UnitTests.Data.Context
                 ModelId = "0921309128012",
                 Orientation = DeviceOrientation.Portrait,
                 Simulator = false,
-                Timezone = TimeZoneInfo.FindSystemTimeZoneById("Central Brazilian Standard Time"),
+                Timezone = TimeZoneInfo.Local,
                 UsableMemory = 100
             };
 
             var actual = JsonConvert.SerializeObject(device);
 
             Assert.That(actual, Is.EqualTo(
-                         "{\"timezone\":\"Central Brazilian Standard Time\"," +
+                         $"{{\"timezone\":\"{TimeZoneInfo.Local.Id}\"," +
                          "\"name\":\"testing.sentry.io\"," +
                          "\"family\":\"Windows\"," +
                          "\"model\":\"Windows Server 2012 R2\"," +


### PR DESCRIPTION
* net45 takes new dependency instead of relying on Win Registry
* TimeZoneInfo Local on tests to bypass Win/Unix string id not mapped
* AppName found on Mono looking at InternalInvoke method
* CPU arch takes Mono approach as fallback (Environment.Is64bit)